### PR TITLE
解析命令行参数时移除外层引号

### DIFF
--- a/HotPatcher/Source/HotPatcherEditor/Classes/Commandlets/HotReleaseCommandlet.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Classes/Commandlets/HotReleaseCommandlet.cpp
@@ -64,7 +64,7 @@ TArray<FPlatformPakListFiles> ParserPlatformPakList(const FString& Commandline)
 
 int32 UHotReleaseCommandlet::Main(const FString& Params)
 {
-	UE_LOG(LogHotReleaseCommandlet, Display, TEXT("UHotReleaseCommandlet::Main"));
+	UE_LOG(LogHotReleaseCommandlet, Display, TEXT("UHotReleaseCommandlet::Main:%s"), *Params);
 
 	FString config_path;
 	bool bStatus = FParse::Value(*Params, *FString(PATCHER_CONFIG_PARAM_NAME).ToLower(), config_path);
@@ -76,7 +76,7 @@ int32 UHotReleaseCommandlet::Main(const FString& Params)
 
 	if (bStatus && !FPaths::FileExists(config_path))
 	{
-		UE_LOG(LogHotReleaseCommandlet, Error, TEXT("cofnig file %s not exists."), *config_path);
+		UE_LOG(LogHotReleaseCommandlet, Error, TEXT("config file %s not exists."), *config_path);
 		return -1;
 	}
 	if(IsRunningCommandlet())

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
@@ -382,7 +382,7 @@ public:
 			SwitchItem.ParseIntoArray(SwitchArray,TEXT("="),true);
 			if(SwitchArray.Num()>1)
 			{
-				resault.Add(SwitchArray[0],SwitchArray[1]);
+				resault.Add(SwitchArray[0],SwitchArray[1].TrimQuotes());
 			}
 			else
 			{


### PR DESCRIPTION
路径存在空格时自动加了引导导致解析出错。

`cmd_list = [
    self._uecmd,
    proj_file,
    f"-run=HotRelease",
    f"-config={opts.config}",
    f"-versionid={opts.version}",
    "-ByPakList=true",
    f"-AddPlatformPakList={pak_list}",
    f"-savePath.path={self.stage_path}",
]
subprocess.run(cmd_list, check=True)`