### PR TITLE
Fixed: Compile issues on macOS and Linux

### DIFF
--- a/HotPatcher/Source/BinariesPatchFeature/Public/BinariesPatchFeature.h
+++ b/HotPatcher/Source/BinariesPatchFeature/Public/BinariesPatchFeature.h
@@ -4,9 +4,10 @@
 #include "Features/IModularFeature.h"
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
-#define BINARIES_DIFF_PATCH_FEATURE_NAME TEXT("BinariesDiffPatchFeatures")
-
+#include "Misc/EnumRange.h"
 #include "BinariesPatchFeature.generated.h"
+
+#define BINARIES_DIFF_PATCH_FEATURE_NAME TEXT("BinariesDiffPatchFeatures")
 
 UENUM(BlueprintType)
 enum class EBinariesPatchFeature:uint8

--- a/HotPatcher/Source/HotPatcherEditor/Private/SHotPatcher.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/SHotPatcher.cpp
@@ -27,7 +27,7 @@
 #include "HAL/PlatformFilemanager.h"
 #include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
-#include "json.h"
+#include "Json.h"
 #include "Misc/SecureHash.h"
 #include "Misc/PackageName.h"
 

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
@@ -20,6 +20,7 @@
 #include "ShaderPipelineCache.h"
 #include "RHI.h"
 #include "Misc/Base64.h"
+#include "Misc/CoreDelegates.h"
 
 void UFlibPakHelper::ExecMountPak(FString InPakPath, int32 InPakOrder, FString InMountPoint)
 {

--- a/HotPatcher/Source/HotPatcherRuntime/Public/ETargetPlatform.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/ETargetPlatform.h
@@ -1,5 +1,7 @@
 #pragma once
+
 #include "CoreMinimal.h"
+#include "Misc/EnumRange.h"
 #include "ETargetPlatform.generated.h"
 
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FBinariesPatchConfig.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FBinariesPatchConfig.h
@@ -6,6 +6,7 @@
 // engine header
 #include "CoreMinimal.h"
 #include "Engine/EngineTypes.h"
+#include "HAL/FileManager.h"
 #include "FBinariesPatchConfig.generated.h"
 
 struct FPakCommandItem

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FExternFileInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FExternFileInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "HotPatcherBaseTypes.h"
 // engine header
+#include "Misc/App.h"
 #include "Misc/Paths.h"
 #include "Misc/SecureHash.h"
 #include "CoreMinimal.h"


### PR DESCRIPTION
Fixed: Compile issues on macOS and Linux based upon Unreal Engine 4.27 and -nopch. 

Some operating systems use a case sensitive file system which applies to includes.