### PR TITLE
Add dummy category specifier to be compatiable as an engine module

### DIFF
--- a/HotPatcher/Source/HotPatcherCore/Public/Cooker/MultiCooker/FSingleCookerSettings.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/Cooker/MultiCooker/FSingleCookerSettings.h
@@ -23,9 +23,9 @@ USTRUCT(BlueprintType)
 struct HOTPATCHERCORE_API FCookerShaderOptions
 {
 	GENERATED_BODY()
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bSharedShaderLibrary = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bNativeShader = false;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cooker",meta=(EditCondition="bSharedShaderLibrary"))
 	bool bMergeShaderLibrary = false;
@@ -36,25 +36,25 @@ struct HOTPATCHERCORE_API FSingleCookerSettings:public FHotPatcherCookerSettingB
 {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString MissionName;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	int32 MissionID = -1;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString ShaderLibName;
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TArray<FAssetDetail> CookAssets;
 
 	// skip loaded assets when cooking(package path)
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TSet<FName> SkipLoadedAssets;
 	
 	// Directories or asset package path
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TArray<FString> SkipCookContents;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	TArray<UClass*> ForceSkipClasses;
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cooker")
@@ -91,10 +91,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Debug")
 	bool bDisplayConfig = false;
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString StorageCookedDir;
 	
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString StorageMetadataDir;
 
 	// UPROPERTY(EditAnywhere,BlueprintReadWrite,Category = "SavePackageContext")
@@ -110,9 +110,9 @@ USTRUCT(BlueprintType)
 struct HOTPATCHERCORE_API FAssetsCollection
 {
 	GENERATED_BODY()
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	ETargetPlatform TargetPlatform = ETargetPlatform::None;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TArray<FAssetDetail> Assets;
 };
 
@@ -121,11 +121,11 @@ struct HOTPATCHERCORE_API FCookerFailedCollection
 {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString MissionName;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	int32 MissionID = -1;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TMap<ETargetPlatform,FAssetsCollection> CookFailedAssets;
 };
 

--- a/HotPatcher/Source/HotPatcherCore/Public/GameFeature/FGameFeaturePackagerSettings.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/GameFeature/FGameFeaturePackagerSettings.h
@@ -39,13 +39,13 @@ public:
 		return &StaticIns;
 	}
 	
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> FeatureNames;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bAutoLoadFeaturePlugin = true;
 	// Config/ Script/ etc.
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	TArray<FString> NonContentDirs;
 	/*
 	 * Cook Asset in current patch

--- a/HotPatcher/Source/HotPatcherCore/Public/HotPatcherSettings.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/HotPatcherSettings.h
@@ -13,11 +13,11 @@ struct FPakExternalInfo
     GENERATED_BODY()
     FPakExternalInfo()=default;
     FPakExternalInfo(const FPakExternalInfo&)=default;
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FString PakName;
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     TArray<ETargetPlatform> TargetPlatforms;
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FPlatformExternAssets AddExternAssetsToPlatform;
 };
 

--- a/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FExportShaderPatchSettings.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FExportShaderPatchSettings.h
@@ -25,16 +25,16 @@ struct FShaderPatchConf
 {
 	GENERATED_USTRUCT_BODY()
 	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		ETargetPlatform Platform = ETargetPlatform::None;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
     	TArray<FDirectoryPath> OldMetadataDir;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
     	FDirectoryPath NewMetadataDir;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
    		bool bNativeFormat = false;
 	// since UE 4.26 (Below 4.26 this parameter has no effect)
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bDeterministicShaderCodeOrder = true;
 };
 

--- a/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FlibShaderPatchHelper.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FlibShaderPatchHelper.h
@@ -20,10 +20,10 @@ class HOTPATCHERCORE_API UFlibShaderPatchHelper : public UBlueprintFunctionLibra
 	GENERATED_BODY()
 public:
 	
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool CreateShaderCodePatch(TArray<FString> const& OldMetaDataDirs, FString const& NewMetaDataDir, FString const& OutDir, bool bNativeFormat,bool bDeterministicShaderCodeOrder = true);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static TArray<FString> ConvDirectoryPathToStr(const TArray<FDirectoryPath>& Dirs);
 
 	static FString ShaderExtension;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDependenciesDetail.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDependenciesDetail.h
@@ -19,10 +19,10 @@ struct HOTPATCHERRUNTIME_API FAssetDependenciesDetail
 		: ModuleCategory(InModuleCategory), AssetDependencyDetails(InDependAssetDetails)
 	{}
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FString ModuleCategory;
 	//UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	//	TArray<FString> mDependAsset;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TMap<FString,FAssetDetail> AssetDependencyDetails;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDependenciesInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDependenciesInfo.h
@@ -13,7 +13,7 @@ struct HOTPATCHERRUNTIME_API FAssetDependenciesInfo
 	FAssetDependenciesInfo(const FAssetDependenciesInfo&)=default;
 		//UPROPERTY(EditAnywhere, BlueprintReadWrite)
 		//FString mAssetRef;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TMap<FString,FAssetDependenciesDetail> AssetsDependenciesMap;
 
 	void AddAssetsDetail(const FAssetDetail& AssetDetail);

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDetail.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDetail.h
@@ -31,11 +31,11 @@ struct HOTPATCHERRUNTIME_API FAssetDetail
 	{
 		return !PackagePath.IsNone() && !AssetType.IsNone() && !Guid.IsNone();
 	}
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FName PackagePath;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FName AssetType;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FName Guid;
 	
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FBinariesPatchConfig.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FBinariesPatchConfig.h
@@ -37,20 +37,20 @@ struct FMatchRule
 {
 	GENERATED_BODY()
 	// match or ignore
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	EMatchRule Rule = EMatchRule::None;
 
 	// grate/less/equal
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	EMatchOperator Operator = EMatchOperator::None;
 
 	// uint kb
-	UPROPERTY(EditAnywhere,meta=(EditCondition="Operator!=EMatchOperator::None"))
+	UPROPERTY(EditAnywhere,meta=(EditCondition="Operator!=EMatchOperator::None"), Category="")
 	float Size = 100;
 	// match file Formats. etc .ini/.lua, if it is empty match everything
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> Formaters;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
     TArray<FString> AssetTypes;
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FChunkInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FChunkInfo.h
@@ -69,15 +69,15 @@ public:
 	const TArray<FString>& GetPakCommands()const{ return PakCommands; }
 	const TArray<FString>& GetIoStoreCommands()const{ return IoStoreCommands; }
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString ChunkName;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString MountPath;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString AssetPackage;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> PakCommands;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> IoStoreCommands;
 
 	EPatchAssetType Type = EPatchAssetType::None;
@@ -88,19 +88,19 @@ struct FPakFileProxy
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString ChunkStoreName;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	ETargetPlatform Platform = ETargetPlatform::None;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString StorageDirectory;
 	// UPROPERTY(EditAnywhere)
 	// FString PakCommandSavePath;
 	// UPROPERTY(EditAnywhere)
 	// FString PakSavePath;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FPakCommand> PakCommands;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> IoStoreCommands;
 };
 
@@ -113,23 +113,23 @@ public:
 	{
 		AssetRegistryDependencyTypes = TArray<EAssetRegistryDependencyTypeEx>{ EAssetRegistryDependencyTypeEx::Packages };
 	}
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString ChunkName;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bMonolithic = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bMonolithic"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bMonolithic"), Category="")
 		EMonolithicPathMode MonolithicPathMode = EMonolithicPathMode::MountPath;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bStorageUnrealPakList = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bStorageIoStorePakList = false;
 	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category = "Assets", meta = (RelativeToGameContentDir, LongPackageName))
 		TArray<FDirectoryPath> AssetIncludeFilters;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Assets", meta = (RelativeToGameContentDir, LongPackageName))
 		TArray<FDirectoryPath> AssetIgnoreFilters;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bAnalysisFilterDependencies = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bAnalysisFilterDependencies"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bAnalysisFilterDependencies"), Category="")
 		TArray<EAssetRegistryDependencyTypeEx> AssetRegistryDependencyTypes;
 	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category = "Assets")
 		TArray<FPatcherSpecifyAsset> IncludeSpecifyAssets;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FCookShaderOptions.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FCookShaderOptions.h
@@ -24,17 +24,17 @@ struct FCookShaderOptions
 	}
 	FString GetShaderLibMountPointRegular()const { return ShderLibMountPointRegular; }
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bSharedShaderLibrary = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bNativeShader = false;
 	// metallib and metalmap to pak?
 	bool bNativeShaderToPak = false;
 	// if name is StartContent to ShaderArchive-StarterContent-PCD3D_SM5.ushaderbytecode
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	EShaderLibNameRule ShaderNameRule = EShaderLibNameRule::CHUNK_NAME;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="ShaderNameRule==EShaderLibNameRule::CUSTOM"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="ShaderNameRule==EShaderLibNameRule::CUSTOM"), Category="")
 	FString CustomShaderName;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FString ShderLibMountPointRegular;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FCookerConfig.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FCookerConfig.h
@@ -9,22 +9,22 @@ struct FCookerConfig
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString EngineBin;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString ProjectPath;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString EngineParams;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> CookPlatforms;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	bool bCookAllMap = false;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> CookMaps;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> CookFilter;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FString> CookSettings;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString Options;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FExternDirectoryInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FExternDirectoryInfo.h
@@ -16,7 +16,7 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "BaseVersion")
 		FDirectoryPath DirectoryPath;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString MountPoint = TEXT("../../../");
 
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FExternFileInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FExternFileInfo.h
@@ -38,7 +38,7 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "BaseVersion", meta = (RelativeToGameContentDir))
 		FFilePath FilePath;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="HotPatcherRunTime | Asset")
 		FString MountPath = TEXT("../../../");
 	UPROPERTY()
 		FString FileHash;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherAssetDependency.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherAssetDependency.h
@@ -12,10 +12,10 @@ struct FHotPatcherAssetDependency
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FAssetDetail Asset;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TArray<FAssetDetail> AssetReference;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		TArray<FAssetDetail> AssetDependency;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherVersion.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherVersion.h
@@ -22,11 +22,11 @@ struct FHotPatcherVersion
 
 public:
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString VersionId;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FString BaseVersionId;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FString Date;
 	// UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TArray<FString> IncludeFilter;
@@ -38,10 +38,10 @@ public:
 	TArray<EAssetRegistryDependencyTypeEx> AssetRegistryDependencyTypes;
 	// UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TArray<FPatcherSpecifyAsset> IncludeSpecifyAssets;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FAssetDependenciesInfo AssetInfo;
 	// UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	// TMap<FString, FExternFileInfo> ExternalFiles;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	TMap<ETargetPlatform,FPlatformExternAssets> PlatformAssets;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FIoStoreSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FIoStoreSettings.h
@@ -23,16 +23,16 @@ struct FIoStorePlatformContainers
 	// │  ThirdPerson_UE5.exe
 	// ├─Engine
 	// └─ThirdPerson_UE5
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FDirectoryPath BasePackageStagedRootDir;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bGenerateDiffPatch = false;
 	
 	// global.utoc file
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FFilePath GlobalContainersOverride;
 	// -PatchSource=E:\UnrealProjects\StarterContent\Releases\1.0\WindowsNoEditor\StarterContent-WindowsNoEditor*.utoc -GenerateDiffPatch
-	UPROPERTY(EditAnywhere,BlueprintReadWrite,meta=(EditCondition="bGenerateDiffPatch"))
+	UPROPERTY(EditAnywhere,BlueprintReadWrite,meta=(EditCondition="bGenerateDiffPatch"), Category="")
 	FFilePath PatchSourceOverride;
 };
 
@@ -41,19 +41,19 @@ struct FIoStoreSettings
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		bool bIoStore = false;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		bool bAllowBulkDataInIoStore = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TArray<FString> IoStorePakListOptions;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TArray<FString> IoStoreCommandletOptions;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TMap<ETargetPlatform,FIoStorePlatformContainers> PlatformContainers;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bStoragePakList = true;
 	// Metadata/BulkDataInfo.ubulkmanifest
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bStorageBulkDataInfo = true;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakEncryptionKeys.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakEncryptionKeys.h
@@ -11,10 +11,10 @@ struct HOTPATCHERRUNTIME_API FPakEncryptSettings
 {
 	GENERATED_BODY()
 	// Use DefaultCrypto.ini
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	bool bUseDefaultCryptoIni = false;
 	// crypto.json (option)
-	UPROPERTY(EditAnywhere,BlueprintReadWrite,meta=(EditCondition="!bUseDefaultCryptoIni"))
+	UPROPERTY(EditAnywhere,BlueprintReadWrite,meta=(EditCondition="!bUseDefaultCryptoIni"), Category="")
 	FFilePath CryptoKeys;
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakFileInfo.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakFileInfo.h
@@ -12,11 +12,11 @@ struct FPakFileInfo
 	GENERATED_USTRUCT_BODY()
 public:
 
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString FileName;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	FString Hash;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 	int32 FileSize = 0;
 	//UPROPERTY(EditAnywhere,BlueprintReadWrite)
 	//FPakVersion PakVersion;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakVersion.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPakVersion.h
@@ -8,12 +8,12 @@ struct FPakVersion
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString VersionId;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString BaseVersionId;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString Date;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString CheckCode;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionAssetDiff.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionAssetDiff.h
@@ -18,10 +18,10 @@ public:
 	FPatchVersionAssetDiff()=default;
 	FPatchVersionAssetDiff(const FPatchVersionAssetDiff&)=default;
 	
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FAssetDependenciesInfo AddAssetDependInfo;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FAssetDependenciesInfo ModifyAssetDependInfo;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FAssetDependenciesInfo DeleteAssetDependInfo;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionDiff.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionDiff.h
@@ -16,13 +16,13 @@ struct FPatchVersionDiff
 	FPatchVersionDiff()=default;
 	FPatchVersionDiff(const FPatchVersionDiff&)=default;
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FPatchVersionAssetDiff AssetDiffInfo;
 	
 	// UPROPERTY(EditAnywhere)
 	// FPatchVersionExternDiff ExternDiffInfo;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TMap<ETargetPlatform,FPatchVersionExternDiff> PlatformExternDiffInfo;
 	
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionExternDiff.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatchVersionExternDiff.h
@@ -16,12 +16,12 @@ struct FPatchVersionExternDiff
 	GENERATED_USTRUCT_BODY()
 	FPatchVersionExternDiff()=default;
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	ETargetPlatform Platform {ETargetPlatform::None};
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FExternFileInfo> AddExternalFiles{};
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FExternFileInfo> ModifyExternalFiles{};
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FExternFileInfo> DeleteExternalFiles{};
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatcherSpecifyAsset.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPatcherSpecifyAsset.h
@@ -23,10 +23,10 @@ public:
 
 		return SameAsset && SameAssetRegistryDependencyTypes && SameAssetRegistryDependencyTypes;
 	}
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FSoftObjectPath Asset;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		bool bAnalysisAssetDependencies = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bAnalysisAssetDependencies"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bAnalysisAssetDependencies"), Category="")
 		TArray<EAssetRegistryDependencyTypeEx> AssetRegistryDependencyTypes;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformBasePak.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformBasePak.h
@@ -14,8 +14,8 @@ struct FPlatformBasePak
     GENERATED_BODY()
     FORCEINLINE FPlatformBasePak()=default;
 	
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     ETargetPlatform Platform = ETargetPlatform::None;
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     TArray<FFilePath> Paks;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformExternAssets.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformExternAssets.h
@@ -15,12 +15,12 @@ struct FPlatformExternAssets
 {
     GENERATED_USTRUCT_BODY()
 
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     ETargetPlatform TargetPlatform = ETargetPlatform::None;
 
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     TArray<FExternFileInfo> AddExternFileToPak;
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     TArray<FExternDirectoryInfo> AddExternDirectoryToPak;
 
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformExternFiles.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPlatformExternFiles.h
@@ -19,8 +19,8 @@ struct FPlatformExternFiles
     FORCEINLINE FPlatformExternFiles(ETargetPlatform InPlatform,const TArray<FExternFileInfo>& InFiles):
         Platform(InPlatform),ExternFiles(InFiles){}
 	
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     ETargetPlatform Platform = ETargetPlatform::None;
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     TArray<FExternFileInfo> ExternFiles;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FReplaceText.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FReplaceText.h
@@ -14,10 +14,10 @@ struct FReplaceText
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString From;
-	UPROPERTY(EditAnywhere,BlueprintReadWrite)
+	UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
 		FString To;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		ESearchCaseMode SearchCase = ESearchCaseMode::CaseSensitive;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FUnrealPakSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FUnrealPakSettings.h
@@ -9,10 +9,10 @@ struct FUnrealPakSettings
 	GENERATED_USTRUCT_BODY()
 public:
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TArray<FString> UnrealPakListOptions;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		TArray<FString> UnrealCommandletOptions;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		bool bStoragePakList = true;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FlibPakHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FlibPakHelper.h
@@ -92,18 +92,18 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "GWorld|Flib|Pak")
 		static TArray<FString> GetAllMountedPaks();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 		static int32 GetPakOrderByPakPath(const FString& PakFile);
 
 
 	// Default Load FApp::GetProjectName() on Enging launching
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 		static bool OpenPSO(const FString& Name);
 
 	static TArray<FString> GetPakFileList(const FString& InPak, const FString& AESKey);
 	static TMap<FString,FPakEntry> GetPakEntrys(FPakFile* InPakFile, const FString& AESKey);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static void DumpPakEntrys(const FString& InPak, const FString& AESKey,const FString& SaveTo);
 	
 	static FString GetPakFileMountPoint(const FString& InPak, const FString& AESKey);
@@ -112,17 +112,17 @@ public:
 
 public:
 	// reload Global&Project shaderbytecode
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static void ReloadShaderbytecode();
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static bool LoadShaderbytecode(const FString& LibraryName, const FString& LibraryDir);
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static bool LoadShaderbytecodeInDefaultDir(const FString& LibraryName);	
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static void CloseShaderbytecode(const FString& LibraryName);
 	
 	static bool LoadAssetRegistryToState(const TCHAR* Path,FAssetRegistryState& Out);
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static bool LoadAssetRegistry(const FString& LibraryName, const FString& LibraryDir);
 	
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
@@ -72,16 +72,16 @@ struct HOTPATCHERRUNTIME_API FAssetRegistryOptions
 	}
 	FString GetAssetRegistryMountPointRegular()const { return AssetRegistryMountPointRegular; }
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bSerializeAssetRegistry = false;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	FString AssetRegistryMountPointRegular;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	EAssetRegistryRule AssetRegistryRule = EAssetRegistryRule::PATCH;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 	bool bCustomAssetRegistryName = false;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bCustomAssetRegistryName"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,meta=(EditCondition="bCustomAssetRegistryName"), Category="")
 	FString AssetRegistryNameRegular;
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportReleaseSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportReleaseSettings.h
@@ -30,13 +30,13 @@ struct HOTPATCHERRUNTIME_API FPlatformPakListFiles
 {
 	GENERATED_USTRUCT_BODY()
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	ETargetPlatform TargetPlatform = ETargetPlatform::None;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FFilePath> PakResponseFiles;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	TArray<FFilePath> PakFiles;
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere, Category="")
 	FString AESKey;
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherContext.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherContext.h
@@ -84,29 +84,29 @@ struct HOTPATCHERRUNTIME_API FHotPatcherPatchContext:public FHotPatcherContext
     class UPatcherProxy* PatchProxy;
     
     // base version content
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FHotPatcherVersion BaseVersion;
     // current project content
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FHotPatcherVersion CurrentVersion;
 
     // base version and current version different
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FPatchVersionDiff VersionDiff;
 
     // final new version content
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FHotPatcherVersion NewReleaseVersion;
 
     // generated current version chunk
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     FChunkInfo NewVersionChunk;
     
     // chunk info
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     TArray<FChunkInfo> PakChunks;
 
-    UPROPERTY(EditAnywhere)
+    UPROPERTY(EditAnywhere, Category="")
     TArray<FPakCommand> AdditionalFileToPak;
     
     // every pak file info
@@ -135,7 +135,7 @@ struct HOTPATCHERRUNTIME_API FHotPatcherReleaseContext:public FHotPatcherContext
     FHotPatcherReleaseContext()=default;
     virtual FExportReleaseSettings* GetSettingObject() { return (FExportReleaseSettings*)ContextSetting; }
     virtual FString GetTotalTimeRecorderName()const{return TEXT("Generate the release total time");}
-    UPROPERTY(BlueprintReadOnly)
+    UPROPERTY(BlueprintReadOnly, Category="")
     FHotPatcherVersion NewReleaseVersion;
     class UReleaseProxy* ReleaseProxy;
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibAssetManageHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibAssetManageHelper.h
@@ -27,9 +27,9 @@ struct FPackageInfo
 {
 	GENERATED_USTRUCT_BODY()
 public:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FString AssetName;
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="")
 		FString AssetGuid;
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
@@ -44,7 +44,7 @@ public:
 		static TArray<FString> GetAvailableMaps(FString GameName, bool IncludeEngineMaps,bool IncludePluginMaps, bool Sorted);
 	UFUNCTION(BlueprintCallable, Category = "HotPatcher|Flib")
 		static FString GetProjectName();
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static FString GetProjectFilePath();
 	
 	static FHotPatcherVersion ExportReleaseVersionInfo(
@@ -215,11 +215,11 @@ public:
 	static FString ParserMountPointRegular(const FString& Src);
 
 public:
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static void ReloadShaderbytecode();
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static bool LoadShaderbytecode(const FString& LibraryName, const FString& LibraryDir);	
-	UFUNCTION(BlueprintCallable,Exec)
+	UFUNCTION(BlueprintCallable,Exec, Category="")
 		static void CloseShaderbytecode(const FString& LibraryName);
 
 public:

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibShaderPipelineCacheHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibShaderPipelineCacheHelper.h
@@ -23,28 +23,28 @@ class HOTPATCHERRUNTIME_API UFlibShaderPipelineCacheHelper : public UBlueprintFu
 {
 	GENERATED_BODY()
 public:
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool LoadShaderPipelineCache(const FString& Name);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool EnableShaderPipelineCache(bool bEnable);
 	
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool SavePipelineFileCache(EPSOSaveMode Mode);
 
 	// r.ShaderPipelineCache.LogPSO
 	// 1 Logs new PSO entries into the file cache and allows saving.
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool EnableLogPSO(bool bEnable);
 	
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool EnableSaveBoundPSOLog(bool bEnable);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool IsEnabledUsePSO();
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool IsEnabledLogPSO();
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="")
 	static bool IsEnabledSaveBoundPSOLog();
 	
 };

--- a/HotPatcher/Source/HotPatcherRuntime/Public/MountListener.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/MountListener.h
@@ -12,9 +12,9 @@ USTRUCT(Blueprintable,BlueprintType)
 struct HOTPATCHERRUNTIME_API FPakMountInfo
 {
     GENERATED_USTRUCT_BODY()
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     FString Pak;
-    UPROPERTY(EditAnywhere,BlueprintReadWrite)
+    UPROPERTY(EditAnywhere,BlueprintReadWrite, Category="")
     int32 PakOrder = 0;
 };
 
@@ -29,7 +29,7 @@ class HOTPATCHERRUNTIME_API UMountListener : public UObject
     GENERATED_UCLASS_BODY()
 public:
 
-    UFUNCTION(BlueprintCallable)
+    UFUNCTION(BlueprintCallable, Category="")
     void Init();   
 
     void OnMountPak(const TCHAR* PakFileName, int32 ChunkID = 0);


### PR DESCRIPTION
Solved #43 by adding dummy categories for those that are not assigned yet. 