### PR TITLE
FReleasePakParser 似乎没计算 hash？

### DIFF
--- a/HotPatcher/Source/HotPatcherRuntime/Private/ReleaseParser/FReleasePakParser.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/ReleaseParser/FReleasePakParser.cpp
@@ -44,7 +44,7 @@ void FReleasePakParser::Parser(TSharedPtr<FReleaseParserConf> ParserConf, EHashC
 		else
 		{
 			// not uasset
-			FExternFileInfo currentFile;
+			FExternFileInfo ExFile;
 			FString RelativePath = MountFile;
 			FString ModuleName;
 			FString ModuleAbsPath;
@@ -54,10 +54,12 @@ void FReleasePakParser::Parser(TSharedPtr<FReleaseParserConf> ParserConf, EHashC
 			UFlibAssetManageHelper::GetEnableModuleAbsDir(ModuleName,ModuleAbsPath);
 			RelativePath.RemoveFromStart(ModuleName);
 			FString FinalFilePath = FPaths::Combine(ModuleAbsPath,RelativePath);
+			FinalFilePath = FinalFilePath.Replace(TEXT("//"), TEXT("/"));
 			FPaths::NormalizeFilename(FinalFilePath);
-			currentFile.FilePath.FilePath = FinalFilePath;
-			currentFile.MountPath = MountFile;
-			result.ExternFiles.AddUnique(currentFile);
+			ExFile.FilePath.FilePath = FinalFilePath;
+			ExFile.MountPath = MountFile;
+			ExFile.GenerateFileHash(HashCalculator);
+			result.ExternFiles.AddUnique(ExFile);
 		}
 	}
 }


### PR DESCRIPTION
这段代码没去算 hash，但 FReleasePaklistParser 的逻辑就计算 hash了， 
使用 Paklist/Pakfile 不应该是等价的么？
这是bug还是故意这么设计的feature？