### PR TITLE
Release v79.0

### DIFF
--- a/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/CommandletHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/CommandletHelper.cpp
@@ -88,7 +88,9 @@ void CommandletHelper::MainTick(TFunction<bool()> IsRequestExit)
 	// main loop
 	FDateTime LastConnectionTime = FDateTime::UtcNow();
 
-	while (GIsRunning && !IsRequestingExit() && !IsRequestExit())
+	while (GIsRunning &&
+		// !IsRequestingExit() &&
+		!IsRequestExit())
 	{
 		GEngine->UpdateTimeAndHandleMaxTickRate();
 		GEngine->Tick(FApp::GetDeltaTime(), false);

--- a/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/HotPatcherCommandlet.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/HotPatcherCommandlet.cpp
@@ -68,7 +68,7 @@ int32 UHotPatcherCommandlet::Main(const FString& Params)
 		
 		FString FinalConfig;
 		THotPatcherTemplateHelper::TSerializeStructAsJsonString(*ExportPatchSetting,FinalConfig);
-		UE_LOG(LogHotPatcherCommandlet, Display, TEXT("%s"), *FinalConfig);
+		// UE_LOG(LogHotPatcherCommandlet, Display, TEXT("%s"), *FinalConfig);
 
 		
 		UPatcherProxy* PatcherProxy = NewObject<UPatcherProxy>();

--- a/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
+++ b/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
@@ -191,7 +191,7 @@ public class HotPatcherCore : ModuleRules
 		{
 			"TOOL_NAME=\"HotPatcher\"",
 			"CURRENT_VERSION_ID=78",
-			"CURRENT_PATCH_ID=0",
+			"CURRENT_PATCH_ID=1",
 			"REMOTE_VERSION_FILE=\"https://imzlp.com/opensource/version.json\""
 		});
 	}

--- a/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
+++ b/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
@@ -190,8 +190,8 @@ public class HotPatcherCore : ModuleRules
 		PublicDefinitions.AddRange(new string[]
 		{
 			"TOOL_NAME=\"HotPatcher\"",
-			"CURRENT_VERSION_ID=78",
-			"CURRENT_PATCH_ID=1",
+			"CURRENT_VERSION_ID=79",
+			"CURRENT_PATCH_ID=0",
 			"REMOTE_VERSION_FILE=\"https://imzlp.com/opensource/version.json\""
 		});
 	}

--- a/HotPatcher/Source/HotPatcherCore/Private/Cooker/PackageWriter/HotWorldPartitionCookPackageSplitter.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/Cooker/PackageWriter/HotWorldPartitionCookPackageSplitter.cpp
@@ -15,7 +15,7 @@
 #include "Editor.h"
 
 // Register FHotWorldPartitionCookPackageSplitter for UWorld class
-REGISTER_COOKPACKAGE_SPLITTER(FHotWorldPartitionCookPackageSplitter, UWorld);
+// REGISTER_COOKPACKAGE_SPLITTER(FHotWorldPartitionCookPackageSplitter, UWorld);
 
 bool FHotWorldPartitionCookPackageSplitter::ShouldSplit(UObject* SplitData)
 {

--- a/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
@@ -158,6 +158,7 @@ namespace PatchWorker
 
 void UPatcherProxy::Init(FPatcherEntitySettingBase* InSetting)
 {
+	SCOPED_NAMED_EVENT_TEXT("UPatcherProxy::Init",FColor::Red);
 	Super::Init(InSetting);
 #if WITH_PACKAGE_CONTEXT
 	PlatformSavePackageContexts = UFlibHotPatcherCoreHelper::CreatePlatformsPackageContexts(
@@ -200,6 +201,7 @@ void UPatcherProxy::Shutdown()
 
 bool UPatcherProxy::DoExport()
 {
+	SCOPED_NAMED_EVENT_TEXT("UPatcherProxy::DoExport",FColor::Red);
 	PatchContext = MakeShareable(new FHotPatcherPatchContext);
 	PatchContext->PatchProxy = this;
 	PatchContext->OnPaking.AddLambda([this](const FString& One,const FString& Msg){this->OnPaking.Broadcast(One,Msg);});
@@ -584,6 +586,7 @@ namespace PatchWorker
 						EmptySetting.bConcurrentSave = false;
 						// for current impl arch
 						EmptySetting.bForceCookInOneFrame = true;
+						EmptySetting.NumberOfAssetsPerFrame = 200;
 						EmptySetting.bDisplayConfig = false;
 						EmptySetting.StorageCookedDir = Context.GetSettingObject()->GetStorageCookedDir();//FPaths::Combine(FPaths::ConvertRelativePathToFull(FPaths::ProjectSavedDir()),TEXT("Cooked"));
 						EmptySetting.StorageMetadataDir = FPaths::Combine(Context.GetSettingObject()->GetSaveAbsPath(),Context.CurrentVersion.VersionId,TEXT("Metadatas"),Chunk.ChunkName);

--- a/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
@@ -2554,8 +2554,10 @@ TempSandboxFile.Get()
 #endif
 	return bresult;
 }
+
 TArray<UClass*> UFlibHotPatcherCoreHelper::GetClassesByNames(const TArray<FName>& ClassesNames)
 {
+	SCOPED_NAMED_EVENT_TEXT("GetClassesByNames",FColor::Red);
 	TArray<UClass*> result;
 	for(const auto& ClassesName:ClassesNames)
 	{
@@ -2573,6 +2575,7 @@ TArray<UClass*> UFlibHotPatcherCoreHelper::GetClassesByNames(const TArray<FName>
 
 TArray<UClass*> UFlibHotPatcherCoreHelper::GetAllMaterialClasses()
 {
+	SCOPED_NAMED_EVENT_TEXT("GetAllMaterialClasses",FColor::Red);
 	TArray<UClass*> Classes;
 	TArray<FName> ParentClassesName = {
 		// materials
@@ -2589,8 +2592,34 @@ TArray<UClass*> UFlibHotPatcherCoreHelper::GetAllMaterialClasses()
 	return Classes;
 }
 
+bool UFlibHotPatcherCoreHelper::IsMaterialClasses(UClass* Class)
+{
+	return UFlibHotPatcherCoreHelper::IsMaterialClassName(Class->GetFName());
+};
+
+bool UFlibHotPatcherCoreHelper::IsMaterialClassName(FName ClassName)
+{
+	return UFlibHotPatcherCoreHelper::GetAllMaterialClassesNames().Contains(ClassName);
+}
+
+bool UFlibHotPatcherCoreHelper::AssetDetailsHasClasses(const TArray<FAssetDetail>& AssetDetails, TSet<FName> ClasssName)
+{
+	SCOPED_NAMED_EVENT_TEXT("AssetDetailsHasClasses",FColor::Red);
+	bool bHas = false;
+	for(const auto& Detail:AssetDetails)
+	{
+		if(ClasssName.Contains(Detail.AssetType))
+		{
+			bHas = true;
+			break;
+		}
+	}
+	return bHas;
+}
+
 TSet<FName> UFlibHotPatcherCoreHelper::GetAllMaterialClassesNames()
 {
+	SCOPED_NAMED_EVENT_TEXT("GetAllMaterialClassesNames",FColor::Red);
 	TSet<FName> result;
 	for(const auto& Class:GetAllMaterialClasses())
 	{
@@ -2653,4 +2682,20 @@ TArray<UClass*> UFlibHotPatcherCoreHelper::GetPreCacheClasses()
 		Results.Add(Class);
 	}
 	return Results.Array();
+}
+
+void UFlibHotPatcherCoreHelper::DumpActiveTargetPlatforms()
+{
+	FString ActiveTargetPlatforms;
+	ITargetPlatformManagerModule* TPM = GetTargetPlatformManager();
+	if (TPM && (TPM->RestrictFormatsToRuntimeOnly() == false))
+	{
+		TArray<ITargetPlatform*> Platforms = TPM->GetActiveTargetPlatforms();
+		for(auto& Platform:Platforms)
+		{
+			ActiveTargetPlatforms += FString::Printf(TEXT("%s,"),*Platform->PlatformName());
+		}
+		ActiveTargetPlatforms.RemoveFromEnd(TEXT(","));
+	}
+	UE_LOG(LogHotPatcherCoreHelper,Display,TEXT("[IMPORTTENT] ActiveTargetPlatforms: %s"),*ActiveTargetPlatforms);
 }

--- a/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
@@ -984,10 +984,15 @@ FString UFlibHotPatcherCoreHelper::ReplacePakRegular(const FReplacePakRegular& R
 		{
 			Result = Result.Replace(*Operator.Name,*(Operator.Do()));
 		}
-		while(Result.Contains(TEXT("__")))
+		auto ReplaceDoubleLambda = [](FString& Src,const FString& From,const FString& To)
 		{
-			Result = Result.Replace(TEXT("__"),TEXT("_"));
-		}
+			while(Src.Contains(From))
+			{
+				Src = Src.Replace(*From,*To);
+			}
+		};
+		ReplaceDoubleLambda(Result,TEXT("__"),TEXT("_"));
+		ReplaceDoubleLambda(Result,TEXT("--"),TEXT("-"));
 		return Result;
 	};
 	
@@ -2708,12 +2713,5 @@ void UFlibHotPatcherCoreHelper::DumpActiveTargetPlatforms()
 
 FString UFlibHotPatcherCoreHelper::GetPlatformsStr(TArray<ETargetPlatform> Platforms)
 {
-	FString result;
-	for(auto Platform:Platforms)
-	{
-		FString PlatformStr = THotPatcherTemplateHelper::GetEnumNameByValue(Platform,false);
-		result+=FString::Printf(TEXT("%s,"),*PlatformStr);
-	}
-	result.RemoveFromEnd(TEXT(","));
-	return result;
+	return UFlibPatchParserHelper::GetPlatformsStr(Platforms);
 }

--- a/HotPatcher/Source/HotPatcherCore/Private/ShaderPatch/FlibShaderCodeLibraryHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/ShaderPatch/FlibShaderCodeLibraryHelper.cpp
@@ -120,10 +120,12 @@ bool UFlibShaderCodeLibraryHelper::SaveShaderLibrary(const ITargetPlatform* Targ
 		#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 25
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 26
 		FString ErrorString;
-		
+#if !UE_VERSION_OLDER_THAN(5,1,0)
+		bool bOutHasData = false;
+#endif
 		bSaved = SHADER_COOKER_CLASS::SaveShaderLibraryWithoutChunking(TargetPlatform, FApp::GetProjectName(), ShaderCodeDir, RootMetaDataPath, PlatformSCLCSVPaths, ErrorString
 #if !UE_VERSION_OLDER_THAN(5,1,0)
-		,false
+		,bOutHasData
 #endif
 		);
 #else

--- a/HotPatcher/Source/HotPatcherCore/Private/ShaderPatch/FlibShaderCodeLibraryHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/ShaderPatch/FlibShaderCodeLibraryHelper.cpp
@@ -120,10 +120,10 @@ bool UFlibShaderCodeLibraryHelper::SaveShaderLibrary(const ITargetPlatform* Targ
 		#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 25
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 26
 		FString ErrorString;
-		bool bOutHasData;
+		
 		bSaved = SHADER_COOKER_CLASS::SaveShaderLibraryWithoutChunking(TargetPlatform, FApp::GetProjectName(), ShaderCodeDir, RootMetaDataPath, PlatformSCLCSVPaths, ErrorString
 #if !UE_VERSION_OLDER_THAN(5,1,0)
-		,bOutHasData
+		,false
 #endif
 		);
 #else

--- a/HotPatcher/Source/HotPatcherCore/Public/CommandletBase/CommandletHelper.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/CommandletBase/CommandletHelper.h
@@ -1,9 +1,7 @@
 #pragma once
 
+#include "CoreMinimal.h"
 #include "ETargetPlatform.h"
-#include "FlibPatchParserHelper.h"
-#include "ThreadUtils/FProcWorkerThread.hpp"
-#include "HotPatcherLog.h"
 
 #define PATCHER_CONFIG_PARAM_NAME TEXT("-config=")
 #define ADD_PATCH_PLATFORMS TEXT("AddPatchPlatforms")

--- a/HotPatcher/Source/HotPatcherCore/Public/FlibHotPatcherCoreHelper.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/FlibHotPatcherCoreHelper.h
@@ -285,7 +285,10 @@ public:
 	static bool SerializeChunksManifests(ITargetPlatform* TargetPlatform, const TSet<FName>&, const TSet<FName>&, bool bGenerateStreamingInstallManifest = true);
 	static TArray<UClass*> GetClassesByNames(const TArray<FName>& ClassesNames);
 	static TArray<UClass*> GetAllMaterialClasses();
+	static bool IsMaterialClasses(UClass* Class);
+	static bool IsMaterialClassName(FName ClassName);
+	static bool AssetDetailsHasClasses(const TArray<FAssetDetail>& AssetDetails,TSet<FName> ClasssName);
 	static TSet<FName> GetAllMaterialClassesNames();
 	static TArray<UClass*> GetPreCacheClasses();
-
+	static void DumpActiveTargetPlatforms();
 };

--- a/HotPatcher/Source/HotPatcherCore/Public/FlibHotPatcherCoreHelper.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/FlibHotPatcherCoreHelper.h
@@ -59,6 +59,17 @@ struct FProjectPackageAssetCollection
 	TArray<FSoftObjectPath> NeverCookPackages;
 };
 
+
+struct HOTPATCHERCORE_API FReplacePakRegular
+{
+	FReplacePakRegular()=default;
+	FReplacePakRegular(const FString& InVersionId,const FString& InBaseVersionId,const FString& InChunkName,const FString& InPlatformName):
+	VersionId(InVersionId),BaseVersionId(InBaseVersionId),ChunkName(InChunkName),PlatformName(InPlatformName){}
+	FString VersionId;
+	FString BaseVersionId;
+	FString ChunkName;
+	FString PlatformName;
+};
 /**
  * 
  */
@@ -161,7 +172,8 @@ public:
 	static FString ReleaseSummary(const FHotPatcherVersion& NewVersion);
 	static FString PatchSummary(const FPatchVersionDiff& DiffInfo);
 
-	static FString MakePakShortName(const FHotPatcherVersion& InCurrentVersion, const FChunkInfo& InChunkInfo, const FString& InPlatform,const FString& InRegular);
+	
+	static FString ReplacePakRegular(const FReplacePakRegular& RegularConf, const FString& InRegular);
 	static bool CheckSelectedAssetsCookStatus(const FString& OverrideCookedDir,const TArray<FString>& PlatformNames, const FAssetDependenciesInfo& SelectedAssets, FString& OutMsg);
 	static bool CheckPatchRequire(const FString& OverrideCookedDir,const FPatchVersionDiff& InDiff,const TArray<FString>& PlatformNames,FString& OutMsg);
 
@@ -277,8 +289,6 @@ public:
 	static void AdaptorOldVersionConfig(FAssetScanConfig& ScanConfig,const FString& JsonContent);
 	
 	static bool GetIniPlatformName(const FString& PlatformName,FString& OutIniPlatformName);
-
-	
 	
 	// need add UNREALED_API to FAssetRegistryGenerator
 	// all chunksinfo.csv / pakchunklist.txt / assetregistry.bin
@@ -291,4 +301,5 @@ public:
 	static TSet<FName> GetAllMaterialClassesNames();
 	static TArray<UClass*> GetPreCacheClasses();
 	static void DumpActiveTargetPlatforms();
+	static FString GetPlatformsStr(TArray<ETargetPlatform> Platforms);
 };

--- a/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FlibShaderCodeLibraryHelper.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/ShaderPatch/FlibShaderCodeLibraryHelper.h
@@ -58,6 +58,7 @@ public:
 	static TArray<FString> FindCookedShaderLibByShaderFrmat(const FString& ShaderFormatName,const FString& Directory);
 
 	static void WaitShaderCompilingComplete();
-
+	static void CancelMaterialShaderCompile(UMaterialInterface* MaterialInterface);
+	
 	static void CleanShaderWorkerDir();
 };

--- a/HotPatcher/Source/HotPatcherEditor/Private/CreatePatch/AssetActions/AssetTypeActions_PrimaryAssetLabel.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/CreatePatch/AssetActions/AssetTypeActions_PrimaryAssetLabel.cpp
@@ -138,7 +138,7 @@ void FAssetTypeActions_PrimaryAssetLabel::MakeCookAndPakActionsSubMenu(UToolMenu
 	FToolMenuSection& Section = Menu->AddSection("CookAndPakActionsSection");
 	UHotPatcherSettings* Settings = GetMutableDefault<UHotPatcherSettings>();
 	Settings->ReloadConfig();
-	for (auto Platform : FHotPatcherEditorModule::Get().GetAllCookPlatforms())
+	for (auto Platform : FHotPatcherEditorModule::Get().GetAllowCookPlatforms())
 	{
 		if(Settings->bWhiteListCookInEditor && !Settings->PlatformWhitelists.Contains(Platform))
 			continue;

--- a/HotPatcher/Source/HotPatcherEditor/Private/FlibHotPatcherEditorHelper.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/FlibHotPatcherEditorHelper.cpp
@@ -1,4 +1,7 @@
 #include "FlibHotPatcherEditorHelper.h"
+
+#include "DesktopPlatformModule.h"
+#include "IDesktopPlatform.h"
 #include "Async/Async.h"
 
 void UFlibHotPatcherEditorHelper::CreateSaveFileNotify(const FText& InMsg, const FString& InSavedFile,
@@ -24,4 +27,46 @@ void UFlibHotPatcherEditorHelper::CreateSaveFileNotify(const FText& InMsg, const
 		Info.HyperlinkText = FText::FromString(HyperLinkText);
 		FSlateNotificationManager::Get().AddNotification(Info)->SetCompletionState(NotifyType);
 	});
+}
+
+TArray<FString> UFlibHotPatcherEditorHelper::SaveFileDialog(const FString& DialogTitle, const FString& DefaultPath,
+	const FString& DefaultFile, const FString& FileTypes, uint32 Flags)
+{
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+
+	TArray<FString> SaveFilenames;
+	if (DesktopPlatform)
+	{
+		const bool bOpened = DesktopPlatform->SaveFileDialog(
+			nullptr,
+			DialogTitle,
+			DefaultPath,
+			DefaultFile,
+			FileTypes,
+			Flags,
+			SaveFilenames
+		);
+	}
+	return SaveFilenames;
+}
+
+TArray<FString> UFlibHotPatcherEditorHelper::OpenFileDialog(const FString& DialogTitle, const FString& DefaultPath,
+	const FString& DefaultFile, const FString& FileTypes, uint32 Flags)
+{
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	TArray<FString> SelectedFiles;
+	
+	if (DesktopPlatform)
+	{
+		const bool bOpened = DesktopPlatform->OpenFileDialog(
+			nullptr,
+			DialogTitle,
+			DefaultPath,
+			DefaultFile,
+			FileTypes,
+			Flags,
+			SelectedFiles
+		);
+	}
+	return SelectedFiles;
 }

--- a/HotPatcher/Source/HotPatcherEditor/Private/HotPatcherEditor.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/HotPatcherEditor.cpp
@@ -454,9 +454,9 @@ void FHotPatcherEditorModule::OnAddToPatchSettings(const FToolMenuContext& MenuC
 
 void FHotPatcherEditorModule::OnPakPreset(FExportPatchSettings Config)
 {
-	TSharedPtr<FExportPatchSettings> PatchSettings = MakeShareable(new FExportPatchSettings);
-	*PatchSettings = Config;
-	CookAndPakByPatchSettings(PatchSettings,PatchSettings->IsStandaloneMode());
+	TSharedPtr<FExportPatchSettings> TmpPatchSettings = MakeShareable(new FExportPatchSettings);
+	*TmpPatchSettings = Config;
+	CookAndPakByPatchSettings(TmpPatchSettings,TmpPatchSettings->IsStandaloneMode());
 }
 
 #endif

--- a/HotPatcher/Source/HotPatcherEditor/Private/HotPatcherEditor.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/HotPatcherEditor.cpp
@@ -330,13 +330,8 @@ void FHotPatcherEditorModule::ExtendContentBrowserPathSelectionMenu()
 void FHotPatcherEditorModule::MakeCookActionsSubMenu(UToolMenu* Menu)
 {
 	FToolMenuSection& Section = Menu->AddSection("CookActionsSection");
-	UHotPatcherSettings* Settings = GetMutableDefault<UHotPatcherSettings>();
-	Settings->ReloadConfig();
-	
-	for (auto Platform : GetAllCookPlatforms())
+	for (auto Platform : GetAllowCookPlatforms())
 	{
-		if(Settings->bWhiteListCookInEditor && !Settings->PlatformWhitelists.Contains(Platform))
-			continue;
 		Section.AddMenuEntry(
             FName(*THotPatcherTemplateHelper::GetEnumNameByValue(Platform)),
             FText::Format(LOCTEXT("Platform", "{0}"), UKismetTextLibrary::Conv_StringToText(THotPatcherTemplateHelper::GetEnumNameByValue(Platform))),
@@ -354,13 +349,9 @@ void FHotPatcherEditorModule::MakeCookAndPakActionsSubMenu(UToolMenu* Menu)
 	FToolMenuSection& Section = Menu->AddSection("CookAndPakActionsSection");
 	UHotPatcherSettings* Settings = GetMutableDefault<UHotPatcherSettings>();
 	Settings->ReloadConfig();
-	for (ETargetPlatform Platform : GetAllCookPlatforms())
+	for (ETargetPlatform Platform : GetAllowCookPlatforms())
 	{
 		FString PlatformName = THotPatcherTemplateHelper::GetEnumNameByValue(Platform);
-		if(PlatformName.StartsWith(TEXT("All")))
-			continue;
-		if(Settings->bWhiteListCookInEditor && !Settings->PlatformWhitelists.Contains(Platform))
-			continue;
 		FToolMenuEntry& PlatformEntry = Section.AddSubMenu(FName(*PlatformName),
 			FText::Format(LOCTEXT("Platform", "{0}"), UKismetTextLibrary::Conv_StringToText(THotPatcherTemplateHelper::GetEnumNameByValue(Platform))),
 			FText(),
@@ -693,6 +684,28 @@ TArray<ETargetPlatform> FHotPatcherEditorModule::GetAllCookPlatforms() const
 			
 	}
 	return TargetPlatforms;
+}
+
+TArray<ETargetPlatform> FHotPatcherEditorModule::GetAllowCookPlatforms() const
+{
+	TArray<ETargetPlatform> results;
+	UHotPatcherSettings* Settings = GetMutableDefault<UHotPatcherSettings>();
+	Settings->ReloadConfig();
+	for (auto Platform : GetAllCookPlatforms())
+	{
+		if(Settings->bWhiteListCookInEditor && !Settings->PlatformWhitelists.Contains(Platform))
+			continue;
+		FString PlatformName = THotPatcherTemplateHelper::GetEnumNameByValue(Platform);
+		if(PlatformName.StartsWith(TEXT("All")))
+			continue;
+		results.AddUnique(Platform);
+	}
+	return results;
+}
+
+void FHotPatcherEditorModule::OnCookPlatformForExterner(ETargetPlatform Platform)
+{
+	FHotPatcherEditorModule::Get().OnCookPlatform(Platform);
 }
 
 TSharedPtr<FProcWorkerThread> FHotPatcherEditorModule::RunProcMission(const FString& Bin, const FString& Command, const FString& MissionName)

--- a/HotPatcher/Source/HotPatcherEditor/Private/SHotPatcherWidgetBase.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/SHotPatcherWidgetBase.cpp
@@ -10,6 +10,7 @@
 // engine header
 #include "IDesktopPlatform.h"
 #include "DesktopPlatformModule.h"
+#include "FlibHotPatcherEditorHelper.h"
 
 #include "Misc/FileHelper.h"
 #include "Widgets/Input/SHyperlink.h"
@@ -44,42 +45,28 @@ FText SHotPatcherWidgetInterface::GetGenerateTooltipText() const
 
 TArray<FString> SHotPatcherWidgetInterface::OpenFileDialog()const
 {
-	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
 	TArray<FString> SelectedFiles;
-	
-	if (DesktopPlatform)
-	{
-		const bool bOpened = DesktopPlatform->OpenFileDialog(
-			nullptr,
+	SelectedFiles = UFlibHotPatcherEditorHelper::OpenFileDialog(
 			LOCTEXT("OpenHotPatchConfigDialog", "Open .json").ToString(),
 			FString(TEXT("")),
 			TEXT(""),
 			TEXT("HotPatcher json (*.json)|*.json"),
-			EFileDialogFlags::None,
-			SelectedFiles
+			EFileDialogFlags::None
 		);
-	}
 	return SelectedFiles;
 }
 
 
 TArray<FString> SHotPatcherWidgetInterface::SaveFileDialog()const
 {
-	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
-
 	TArray<FString> SaveFilenames;
-	if (DesktopPlatform)
-	{
-		const bool bOpened = DesktopPlatform->SaveFileDialog(
-			nullptr,
+	SaveFilenames = UFlibHotPatcherEditorHelper::SaveFileDialog(
 			LOCTEXT("SvedHotPatcherConfig", "Save .json").ToString(),
 			FString(TEXT("")),
 			TEXT(""),
 			TEXT("HotPatcher json (*.json)|*.json"),
-			EFileDialogFlags::None,
-			SaveFilenames
+			EFileDialogFlags::None
 		);
-	}
 	return SaveFilenames;
 }
 

--- a/HotPatcher/Source/HotPatcherEditor/Public/FlibHotPatcherEditorHelper.h
+++ b/HotPatcher/Source/HotPatcherEditor/Public/FlibHotPatcherEditorHelper.h
@@ -3,6 +3,7 @@
 // engine header
 #include "Templates/SharedPointer.h"
 #include "Dom/JsonObject.h"
+#include "IDesktopPlatform.h"
 #include "CoreMinimal.h"
 #include "Framework/Notifications/NotificationManager.h"
 #include "Widgets/Notifications/SNotificationList.h"
@@ -14,7 +15,8 @@ class HOTPATCHEREDITOR_API UFlibHotPatcherEditorHelper : public UBlueprintFuncti
 	GENERATED_BODY()
 public:
 	static void CreateSaveFileNotify(const FText& InMsg,const FString& InSavedFile,SNotificationItem::ECompletionState NotifyType = SNotificationItem::CS_Success);
-
+	static TArray<FString> SaveFileDialog(const FString& DialogTitle, const FString& DefaultPath, const FString& DefaultFile, const FString& FileTypes, uint32 Flags);
+	static TArray<FString> OpenFileDialog(const FString& DialogTitle, const FString& DefaultPath, const FString& DefaultFile, const FString& FileTypes, uint32 Flags);
 };
 
 

--- a/HotPatcher/Source/HotPatcherEditor/Public/HotPatcherEditor.h
+++ b/HotPatcher/Source/HotPatcherEditor/Public/HotPatcherEditor.h
@@ -70,7 +70,8 @@ public:
 	void MakeHotPatcherPresetsActionsSubMenu(UToolMenu* Menu);
 	void OnAddToPatchSettings(const FToolMenuContext& MenuContent);
 #endif
-	TArray<ETargetPlatform> GetAllCookPlatforms()const;
+	TArray<ETargetPlatform> GetAllowCookPlatforms() const;
+	static void OnCookPlatformForExterner(ETargetPlatform Platform);;
 	void OnCookPlatform(ETargetPlatform Platform);
 	void OnCookAndPakPlatform(ETargetPlatform Platform, bool bAnalysicDependencies);
 	void CookAndPakByAssetsAndFilters(TArray<FPatcherSpecifyAsset> IncludeAssets,TArray<FDirectoryPath> IncludePaths,TArray<ETargetPlatform> Platforms,bool bForceStandalone = false);
@@ -89,6 +90,7 @@ public:
 		bool bCook
 	);
 private:
+	TArray<ETargetPlatform> GetAllCookPlatforms()const;
 	TSharedRef<class SDockTab> OnSpawnPluginTab(const class FSpawnTabArgs& InSpawnTabArgs);
 	void OnTabClosed(TSharedRef<SDockTab> InTab);
 	TArray<FAssetData> GetSelectedAssetsInBrowserContent();

--- a/HotPatcher/Source/HotPatcherEditor/Public/HotPatcherEditor.h
+++ b/HotPatcher/Source/HotPatcherEditor/Public/HotPatcherEditor.h
@@ -56,7 +56,7 @@ public:
 
 	TSharedPtr<FProcWorkerThread> CreateProcMissionThread(const FString& Bin, const FString& Command, const FString& MissionName);
 	
-	TSharedPtr<FProcWorkerThread> RunProcMission(const FString& Bin, const FString& Command, const FString& MissionName);
+	TSharedPtr<FProcWorkerThread> RunProcMission(const FString& Bin, const FString& Command, const FString& MissionName, const FText& NotifyTextOverride = FText{});
 
 	
 #if WITH_EDITOR_SECTION

--- a/HotPatcher/Source/HotPatcherRuntime/Private/BaseTypes/FChunkInfo.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/BaseTypes/FChunkInfo.cpp
@@ -31,6 +31,7 @@ FString FChunkInfo::GetShaderLibraryName() const
 
 TArray<FSoftObjectPath> FChunkInfo::GetManagedAssets() const
 {
+	SCOPED_NAMED_EVENT_TEXT("FChunkInfo::GetManagedAssets",FColor::Red);
 	TArray<FSoftObjectPath> NewPaths;
 	
 	UAssetManager& Manager = UAssetManager::Get();

--- a/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/FExportPatchSettings.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/FExportPatchSettings.cpp
@@ -129,11 +129,11 @@ FString FExportPatchSettings::GetCurrentVersionSavePath() const
 
 FString FExportPatchSettings::GetCombinedAdditionalCommandletArgs() const
 {
-	FString Result = FString::Printf(TEXT("%s %s"),
-		*FHotPatcherSettingBase::GetCombinedAdditionalCommandletArgs(),
-		*UFlibPatchParserHelper::GetTargetPlatformsCmdLine(GetPakTargetPlatforms())
-		);
-	return Result;
+	return UFlibPatchParserHelper::MergeOptionsAsCmdline(TArray<FString>{
+		FHotPatcherSettingBase::GetCombinedAdditionalCommandletArgs(),
+		UFlibPatchParserHelper::GetTargetPlatformsCmdLine(GetPakTargetPlatforms()),
+		IsEnableProfiling() ? TEXT("-trace=cpu,loadtimetrace") : TEXT("")
+	});
 }
 
 FString FExportPatchSettings::GetStorageCookedDir() const

--- a/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/FExportPatchSettings.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/FExportPatchSettings.cpp
@@ -127,6 +127,15 @@ FString FExportPatchSettings::GetCurrentVersionSavePath() const
 	return CurrentVersionSavePath;
 }
 
+FString FExportPatchSettings::GetCombinedAdditionalCommandletArgs() const
+{
+	FString Result = FString::Printf(TEXT("%s %s"),
+		*FHotPatcherSettingBase::GetCombinedAdditionalCommandletArgs(),
+		*UFlibPatchParserHelper::GetTargetPlatformsCmdLine(GetPakTargetPlatforms())
+		);
+	return Result;
+}
+
 FString FExportPatchSettings::GetStorageCookedDir() const
 {
 	return UFlibPatchParserHelper::ReplaceMark(StorageCookedDir);

--- a/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/HotPatcherSettingBase.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/HotPatcherSettingBase.cpp
@@ -102,6 +102,21 @@ FString FHotPatcherSettingBase::GetSaveAbsPath()const
 }
 
 
+FString FHotPatcherSettingBase::GetCombinedAdditionalCommandletArgs() const
+{
+	FString Result;
+	
+	// for(const auto& Option:GetAdditionalCommandletArgs())
+	// {
+	// 	Result+=FString::Printf(TEXT("%s "),*Option);
+	// }
+	
+	TArray<FString> Options = GetAdditionalCommandletArgs();
+	Options.AddUnique(TEXT("-NoPostLoadCacheDDC"));
+	Result = UFlibPatchParserHelper::MergeOptionsAsCmdline(Options);
+	return Result;
+}
+
 TArray<FString> FHotPatcherSettingBase::GetAllSkipContents() const
 
 {

--- a/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/HotPatcherSettingBase.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/CreatePatch/HotPatcherSettingBase.cpp
@@ -3,6 +3,8 @@
 #include "FPlatformExternFiles.h"
 #include "HotPatcherLog.h"
 
+#include "Misc/EngineVersionComparison.h"
+
 FHotPatcherSettingBase::FHotPatcherSettingBase()
 {
 	GetAssetScanConfigRef().bAnalysisFilterDependencies = true;
@@ -101,24 +103,18 @@ FString FHotPatcherSettingBase::GetSaveAbsPath()const
 	return TEXT("");
 }
 
-
 FString FHotPatcherSettingBase::GetCombinedAdditionalCommandletArgs() const
 {
 	FString Result;
-	
-	// for(const auto& Option:GetAdditionalCommandletArgs())
-	// {
-	// 	Result+=FString::Printf(TEXT("%s "),*Option);
-	// }
-	
 	TArray<FString> Options = GetAdditionalCommandletArgs();
+#if UE_VERSION_OLDER_THAN(5,0,0)
 	Options.AddUnique(TEXT("-NoPostLoadCacheDDC"));
+#endif
 	Result = UFlibPatchParserHelper::MergeOptionsAsCmdline(Options);
 	return Result;
 }
 
 TArray<FString> FHotPatcherSettingBase::GetAllSkipContents() const
-
 {
 	TArray<FString> AllSkipContents;;
 	AllSkipContents.Append(UFlibAssetManageHelper::DirectoriesToStrings(GetForceSkipContentRules()));

--- a/HotPatcher/Source/HotPatcherRuntime/Private/DependenciesParser/FDefaultAssetDependenciesParser.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/DependenciesParser/FDefaultAssetDependenciesParser.cpp
@@ -65,7 +65,7 @@ void FAssetDependenciesParser::Parse(const FAssetDependencies& InParseConfig)
 				continue;
 			}
 			FAssetData AssetData;
-			if(UFlibAssetManageHelper::GetAssetsDataByPackageName(LongPackageName,AssetData))
+			if(!LongPackageName.IsEmpty() && UFlibAssetManageHelper::GetAssetsDataByPackageName(LongPackageName,AssetData))
 			{
 				if(IsIgnoreAsset(AssetData))
 				{

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibAssetManageHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibAssetManageHelper.cpp
@@ -135,6 +135,18 @@ bool UFlibAssetManageHelper::GetAssetPackageGUID(const FString& InPackageName, F
 	return bResult;
 }
 
+FSoftObjectPath UFlibAssetManageHelper::CreateSoftObjectPathByPackage(UPackage* Package)
+{
+	FString AssetPathName = Package->GetPathName();	
+	FSoftObjectPath Path(UFlibAssetManageHelper::LongPackageNameToPackagePath(AssetPathName));
+	return Path;
+}
+
+FName UFlibAssetManageHelper::GetAssetTypeByPackage(UPackage* Package)
+{
+	return UFlibAssetManageHelper::GetAssetType(CreateSoftObjectPathByPackage(Package));
+}
+
 
 FAssetDependenciesInfo UFlibAssetManageHelper::CombineAssetDependencies(const FAssetDependenciesInfo& A, const FAssetDependenciesInfo& B)
 {
@@ -1585,4 +1597,14 @@ FName UFlibAssetManageHelper::GetObjectPathByAssetData(const FAssetData& Data)
 	return NAME_None;
 }
 
+void UFlibAssetManageHelper::UpdateAssetRegistryData(const FString& PackageName)
+{
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+	FString PackageFilename;
+	if (FPackageName::FindPackageFileWithoutExtension(FPackageName::LongPackageNameToFilename(PackageName), PackageFilename))
+	{
+		AssetRegistry.ScanModifiedAssetFiles(TArray<FString>{PackageFilename});
+	}
+}
 // PRAGMA_ENABLE_DEPRECATION_WARNINGS

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibAssetManageHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibAssetManageHelper.cpp
@@ -715,7 +715,8 @@ SCOPED_NAMED_EVENT_TEXT("UFlibAssetManageHelper::GetAllInValidAssetInProject",FC
 		}
 	}
 }
-
+#pragma warning(push)
+#pragma warning(disable:4172)
 FAssetPackageData* UFlibAssetManageHelper::GetPackageDataByPackageName(const FString& InPackageName)
 {
 	FAssetPackageData* AssetPackageData = nullptr;
@@ -746,6 +747,7 @@ FAssetPackageData* UFlibAssetManageHelper::GetPackageDataByPackageName(const FSt
 
 	return NULL;
 }
+#pragma warning(pop)
 
 bool UFlibAssetManageHelper::ConvLongPackageNameToCookedPath(
 	const FString& InProjectAbsDir,

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
@@ -927,113 +927,117 @@ FChunkAssetDescribe UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
 	const FChunkInfo& Chunk, TArray<ETargetPlatform> Platforms
 )
 {
+	SCOPED_NAMED_EVENT_TEXT("CollectFChunkAssetsDescribeByChunk",FColor::Red);
 	FChunkAssetDescribe ChunkAssetDescribe;
 	// Collect Chunk Assets
+	// {
+	// 	
+	// 	FAssetDependenciesInfo SpecifyDependAssets;
+	// 	
+	// 	FAssetDependenciesParser Parser;
+	// 	FAssetDependencies Conf;
+	// 	TArray<FString> AssetFilterPaths = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.AssetIncludeFilters);
+	// 	Conf.IncludeFilters = AssetFilterPaths;
+	// 	Conf.IgnoreFilters = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.AssetIgnoreFilters);
+	// 	Conf.ForceSkipPackageNames = UFlibAssetManageHelper::SoftObjectPathsToStrings(Chunk.ForceSkipAssets);
+	// 	Conf.InIncludeSpecifyAsset = Chunk.IncludeSpecifyAssets;
+	// 	Conf.AssetRegistryDependencyTypes = Chunk.AssetRegistryDependencyTypes;
+	// 	Conf.AnalysicFilterDependencies = Chunk.bAnalysisFilterDependencies;
+	// 	Conf.ForceSkipContents = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.ForceSkipContentRules);
+	// 	Conf.ForceSkipContents.Append(UFlibAssetManageHelper::DirectoriesToStrings(PatcheSettings->GetAssetScanConfig().ForceSkipContentRules));
+	// 	
+	// 	auto AddForceSkipAssets = [&Conf](const TArray<FSoftObjectPath>& Assets)
+	// 	{
+	// 		for(const auto& forceSkipAsset:Assets)
+	// 		{
+	// 			Conf.ForceSkipContents.Add(forceSkipAsset.GetLongPackageName());
+	// 		}
+	// 	};
+	// 	AddForceSkipAssets(Chunk.ForceSkipAssets);
+	// 	AddForceSkipAssets(PatcheSettings->GetAssetScanConfig().ForceSkipAssets);
+	// 	
+	// 	auto AddSkipClassesLambda = [&Conf](const TArray<UClass*>& Classes)
+	// 	{
+	// 		for(const auto& ForceSkipClass:Classes)
+	// 		{
+	// 			Conf.IgnoreAseetTypes.Add(*ForceSkipClass->GetName());
+	// 		}
+	// 	};
+	// 	AddSkipClassesLambda(Chunk.ForceSkipClasses);
+	// 	AddSkipClassesLambda(PatcheSettings->GetAssetScanConfig().ForceSkipClasses);
+	// 	
+	// 	Parser.Parse(Conf);
+	// 	TSet<FName> AssetLongPackageNames = Parser.GetrParseResults();
+	//
+	// 	for(FName LongPackageName:AssetLongPackageNames)
+	// 	{
+	// 		if(LongPackageName.IsNone())
+	// 		{
+	// 			continue;
+	// 		}
+	// 		AssetFilterPaths.AddUnique(LongPackageName.ToString());
+	// 	}
+	//
+	// 	const FAssetDependenciesInfo& AddAssetsRef = DiffInfo.AssetDiffInfo.AddAssetDependInfo;
+	// 	const FAssetDependenciesInfo& ModifyAssetsRef = DiffInfo.AssetDiffInfo.ModifyAssetDependInfo;
+	//
+	//
+	// 	auto CollectChunkAssets = [](const FAssetDependenciesInfo& SearchBase, const TArray<FString>& SearchFilters)->FAssetDependenciesInfo
+	// 	{
+	// 		SCOPED_NAMED_EVENT_TEXT("CollectChunkAssets",FColor::Red);
+	// 		FAssetDependenciesInfo ResultAssetDependInfos;
+	//
+	// 		for (const auto& SearchItem : SearchFilters)
+	// 		{
+	// 			if (SearchItem.IsEmpty())
+	// 				continue;
+	//
+	// 			FString SearchModuleName;
+	// 			int32 findedPos = SearchItem.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, 1);
+	// 			if (findedPos != INDEX_NONE)
+	// 			{
+	// 				SearchModuleName = UKismetStringLibrary::GetSubstring(SearchItem, 1, findedPos - 1);
+	// 			}
+	// 			else
+	// 			{
+	// 				SearchModuleName = UKismetStringLibrary::GetSubstring(SearchItem, 1, SearchItem.Len() - 1);
+	// 			}
+	//
+	// 			if (!SearchModuleName.IsEmpty() && (SearchBase.AssetsDependenciesMap.Contains(SearchModuleName)))
+	// 			{
+	// 				if (!ResultAssetDependInfos.AssetsDependenciesMap.Contains(SearchModuleName))
+	// 					ResultAssetDependInfos.AssetsDependenciesMap.Add(SearchModuleName, FAssetDependenciesDetail(SearchModuleName, TMap<FString, FAssetDetail>{}));
+	//
+	// 				const FAssetDependenciesDetail& SearchBaseModule = *SearchBase.AssetsDependenciesMap.Find(SearchModuleName);
+	//
+	// 				TArray<FString> AllAssetKeys;
+	// 				SearchBaseModule.AssetDependencyDetails.GetKeys(AllAssetKeys);
+	//
+	// 				for (const auto& KeyItem : AllAssetKeys)
+	// 				{
+	// 					if (KeyItem.StartsWith(SearchItem))
+	// 					{
+	// 						FAssetDetail FindedAsset = *SearchBaseModule.AssetDependencyDetails.Find(KeyItem);
+	// 						if (!ResultAssetDependInfos.AssetsDependenciesMap.Find(SearchModuleName)->AssetDependencyDetails.Contains(KeyItem))
+	// 						{
+	// 							ResultAssetDependInfos.AssetsDependenciesMap.Find(SearchModuleName)->AssetDependencyDetails.Add(KeyItem, FindedAsset);
+	// 						}
+	// 					}
+	// 				}
+	// 			}
+	// 		}
+	// 		return ResultAssetDependInfos;
+	// 	};
+	//}
 	{
-		
-		FAssetDependenciesInfo SpecifyDependAssets;
-		
-		FAssetDependenciesParser Parser;
-		FAssetDependencies Conf;
-		TArray<FString> AssetFilterPaths = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.AssetIncludeFilters);
-		Conf.IncludeFilters = AssetFilterPaths;
-		Conf.IgnoreFilters = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.AssetIgnoreFilters);
-		Conf.ForceSkipPackageNames = UFlibAssetManageHelper::SoftObjectPathsToStrings(Chunk.ForceSkipAssets);
-		Conf.InIncludeSpecifyAsset = Chunk.IncludeSpecifyAssets;
-		Conf.AssetRegistryDependencyTypes = Chunk.AssetRegistryDependencyTypes;
-		Conf.AnalysicFilterDependencies = Chunk.bAnalysisFilterDependencies;
-		Conf.ForceSkipContents = UFlibAssetManageHelper::DirectoriesToStrings(Chunk.ForceSkipContentRules);
-		Conf.ForceSkipContents.Append(UFlibAssetManageHelper::DirectoriesToStrings(PatcheSettings->GetAssetScanConfig().ForceSkipContentRules));
-		
-		auto AddForceSkipAssets = [&Conf](const TArray<FSoftObjectPath>& Assets)
-		{
-			for(const auto& forceSkipAsset:Assets)
-			{
-				Conf.ForceSkipContents.Add(forceSkipAsset.GetLongPackageName());
-			}
-		};
-		AddForceSkipAssets(Chunk.ForceSkipAssets);
-		AddForceSkipAssets(PatcheSettings->GetAssetScanConfig().ForceSkipAssets);
-		
-		auto AddSkipClassesLambda = [&Conf](const TArray<UClass*>& Classes)
-		{
-			for(const auto& ForceSkipClass:Classes)
-			{
-				Conf.IgnoreAseetTypes.Add(*ForceSkipClass->GetName());
-			}
-		};
-		AddSkipClassesLambda(Chunk.ForceSkipClasses);
-		AddSkipClassesLambda(PatcheSettings->GetAssetScanConfig().ForceSkipClasses);
-		
-		Parser.Parse(Conf);
-		TSet<FName> AssetLongPackageNames = Parser.GetrParseResults();
-
-		for(FName LongPackageName:AssetLongPackageNames)
-		{
-			if(LongPackageName.IsNone())
-			{
-				continue;
-			}
-			AssetFilterPaths.AddUnique(LongPackageName.ToString());
-		}
-
-		const FAssetDependenciesInfo& AddAssetsRef = DiffInfo.AssetDiffInfo.AddAssetDependInfo;
-		const FAssetDependenciesInfo& ModifyAssetsRef = DiffInfo.AssetDiffInfo.ModifyAssetDependInfo;
-
-
-		auto CollectChunkAssets = [](const FAssetDependenciesInfo& SearchBase, const TArray<FString>& SearchFilters)->FAssetDependenciesInfo
-		{
-			FAssetDependenciesInfo ResultAssetDependInfos;
-
-			for (const auto& SearchItem : SearchFilters)
-			{
-				if (SearchItem.IsEmpty())
-					continue;
-
-				FString SearchModuleName;
-				int32 findedPos = SearchItem.Find(TEXT("/"), ESearchCase::IgnoreCase, ESearchDir::FromStart, 1);
-				if (findedPos != INDEX_NONE)
-				{
-					SearchModuleName = UKismetStringLibrary::GetSubstring(SearchItem, 1, findedPos - 1);
-				}
-				else
-				{
-					SearchModuleName = UKismetStringLibrary::GetSubstring(SearchItem, 1, SearchItem.Len() - 1);
-				}
-
-				if (!SearchModuleName.IsEmpty() && (SearchBase.AssetsDependenciesMap.Contains(SearchModuleName)))
-				{
-					if (!ResultAssetDependInfos.AssetsDependenciesMap.Contains(SearchModuleName))
-						ResultAssetDependInfos.AssetsDependenciesMap.Add(SearchModuleName, FAssetDependenciesDetail(SearchModuleName, TMap<FString, FAssetDetail>{}));
-
-					const FAssetDependenciesDetail& SearchBaseModule = *SearchBase.AssetsDependenciesMap.Find(SearchModuleName);
-
-					TArray<FString> AllAssetKeys;
-					SearchBaseModule.AssetDependencyDetails.GetKeys(AllAssetKeys);
-
-					for (const auto& KeyItem : AllAssetKeys)
-					{
-						if (KeyItem.StartsWith(SearchItem))
-						{
-							FAssetDetail FindedAsset = *SearchBaseModule.AssetDependencyDetails.Find(KeyItem);
-							if (!ResultAssetDependInfos.AssetsDependenciesMap.Find(SearchModuleName)->AssetDependencyDetails.Contains(KeyItem))
-							{
-								ResultAssetDependInfos.AssetsDependenciesMap.Find(SearchModuleName)->AssetDependencyDetails.Add(KeyItem, FindedAsset);
-							}
-						}
-					}
-				}
-			}
-			return ResultAssetDependInfos;
-		};
-		
-		ChunkAssetDescribe.AddAssets = CollectChunkAssets(AddAssetsRef, AssetFilterPaths);
-		ChunkAssetDescribe.ModifyAssets = CollectChunkAssets(ModifyAssetsRef, AssetFilterPaths);
+		ChunkAssetDescribe.AddAssets = DiffInfo.AssetDiffInfo.AddAssetDependInfo; // CollectChunkAssets(AddAssetsRef, AssetFilterPaths);
+		ChunkAssetDescribe.ModifyAssets = DiffInfo.AssetDiffInfo.ModifyAssetDependInfo; //CollectChunkAssets(ModifyAssetsRef, AssetFilterPaths);
 		ChunkAssetDescribe.Assets = UFlibAssetManageHelper::CombineAssetDependencies(ChunkAssetDescribe.AddAssets, ChunkAssetDescribe.ModifyAssets);
 	}
 
 	auto CoolectPlatformExFiles = [](const FPatchVersionDiff& DiffInfo,const auto& Chunk,ETargetPlatform Platform)->TArray<FExternFileInfo>
 	{
+		SCOPED_NAMED_EVENT_TEXT("CoolectPlatformExFiles",FColor::Red);
 		// Collect Extern Files
 		TArray<FExternFileInfo> AllFiles;
 
@@ -1281,6 +1285,7 @@ FHotPatcherVersion UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
 	}
 
 	FAssetScanConfig ScanConfig;
+	ScanConfig.bPackageTracker = false;
 	ScanConfig.AssetIncludeFilters = InChunkInfo.AssetIncludeFilters;
 	ScanConfig.AssetIgnoreFilters = InChunkInfo.AssetIgnoreFilters;
 	ScanConfig.bAnalysisFilterDependencies = bInAnalysisFilterDependencies;
@@ -2137,3 +2142,60 @@ bool UFlibPatchParserHelper::IsValidPatchSettings(const FExportPatchSettings* Pa
 	}
 	return bCanExport;
 }
+
+FString UFlibPatchParserHelper::GetTargetPlatformsCmdLine(const TArray<ETargetPlatform>& Platforms)
+{
+	FString Result;
+	if(Platforms.Num())
+	{
+		FString PlatformArrayStr;
+		for(ETargetPlatform Platform:Platforms)
+		{
+			FString PlatformName = THotPatcherTemplateHelper::GetEnumNameByValue(Platform);
+			PlatformArrayStr += FString::Printf(TEXT("%s+"),*PlatformName);
+		}
+		PlatformArrayStr.RemoveFromEnd(TEXT("+"));
+		if(!PlatformArrayStr.IsEmpty())
+		{
+			Result = FString::Printf(TEXT("-TargetPlatform=%s"),*PlatformArrayStr);
+		}
+	}
+	return Result;
+}
+
+void UFlibPatchParserHelper::SetPropertyTransient(UStruct* Struct,const FString& PropertyName,bool bTransient)
+{
+	for(TFieldIterator<FProperty> PropertyIter(Struct);PropertyIter;++PropertyIter)
+	{
+		FProperty* PropertyIns = *PropertyIter;
+		if(PropertyName.Equals(*PropertyIns->GetName(),ESearchCase::IgnoreCase))
+		{
+			if(bTransient)
+			{
+				PropertyIns->SetPropertyFlags(CPF_Transient);
+			}
+			else
+			{
+				PropertyIns->ClearPropertyFlags(CPF_Transient);
+			}
+			break;
+		}
+	}
+}
+
+FString UFlibPatchParserHelper::MergeOptionsAsCmdline(const TArray<FString>& InOptions)
+{
+	FString Cmdline;
+	for(const auto& Option:InOptions)
+	{
+		FString InOption = Option;
+		while(InOption.RemoveFromStart(TEXT(" "))){}
+		while(InOption.RemoveFromEnd(TEXT(" "))){}
+		if(!InOption.IsEmpty())
+		{
+			Cmdline += FString::Printf(TEXT("%s "),*InOption);
+		}
+	}
+	Cmdline.RemoveFromEnd(TEXT(" "));
+	return Cmdline;
+};

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherVersion.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FHotPatcherVersion.h
@@ -21,7 +21,8 @@ struct FHotPatcherVersion
 	GENERATED_USTRUCT_BODY()
 
 public:
-
+	FHotPatcherVersion()=default;
+	
 	UPROPERTY(EditAnywhere,BlueprintReadWrite)
 	FString VersionId;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPackageTracker.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/FPackageTracker.h
@@ -111,3 +111,36 @@ protected:
 	TSet<FName>	 PackagesPendingSave;
 	TSet<FName>& ExisitAssets;
 };
+
+struct FClassesPackageTracker : public FPackageTrackerBase
+{
+	virtual void OnPackageCreated(UPackage* Package) override
+	{
+		FName ClassName = UFlibAssetManageHelper::GetAssetTypeByPackage(Package);
+		
+		if(!ClassMapping.Contains(ClassName))
+		{
+			ClassMapping.Add(ClassName,TArray<UPackage*>{});
+		}
+		ClassMapping.Find(ClassName)->AddUnique(Package);
+	};
+	virtual void OnPackageDeleted(UPackage* Package) override
+	{
+		FName ClassName = UFlibAssetManageHelper::GetAssetTypeByPackage(Package);
+		if(ClassMapping.Contains(ClassName))
+		{
+			ClassMapping.Find(ClassName)->Remove(Package);
+		}
+	}
+	TArray<UPackage*> GetPackagesByClassName(FName ClassName)
+	{
+		TArray<UPackage*> result;
+		if(ClassMapping.Contains(ClassName))
+		{
+			result = *ClassMapping.Find(ClassName);
+		}
+		return result;
+	}
+protected:
+	TMap<FName,TArray<UPackage*>> ClassMapping;
+};

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
@@ -124,6 +124,8 @@ public:
 	FORCEINLINE FCookShaderOptions GetCookShaderOptions()const {return CookShaderOptions;}
 	FORCEINLINE FAssetRegistryOptions GetSerializeAssetRegistryOptions()const{return SerializeAssetRegistryOptions;}
 	FORCEINLINE bool IsImportProjectSettings()const{ return bImportProjectSettings; }
+
+	virtual FString GetCombinedAdditionalCommandletArgs()const override;
 public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "BaseVersion")
 		bool bByBaseVersion = false;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/FExportPatchSettings.h
@@ -98,11 +98,11 @@ public:
 
 	FORCEINLINE bool IsCustomPakNameRegular()const {return bCustomPakNameRegular;}
 	FORCEINLINE FString GetPakNameRegular()const { return PakNameRegular;}
+	FORCEINLINE bool IsCustomPakSaveDirRegular()const {return bCustomPakSaveDirRegular;}
+	FORCEINLINE FString GetPakSaveDirRegular()const { return PakSaveDirRegular;}
 	FORCEINLINE bool IsCookPatchAssets()const {return bCookPatchAssets;}
 	FORCEINLINE bool IsIgnoreDeletedAssetsInfo()const {return bIgnoreDeletedAssetsInfo;}
 	FORCEINLINE bool IsSaveDeletedAssetsToNewReleaseJson()const {return bStorageDeletedAssetsToNewReleaseJson;}
-	
-	
 	
 	FORCEINLINE FIoStoreSettings GetIoStoreSettings()const { return IoStoreSettings; }
 	FORCEINLINE FUnrealPakSettings GetUnrealPakSettings()const {return UnrealPakSettings;}
@@ -225,8 +225,13 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Pak Options")
 		bool bCustomPakNameRegular = false;
 	// Can use value: {VERSION} {BASEVERSION} {CHUNKNAME} {PLATFORM} 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Pak Options",meta=(EditCondition = "bCustomPakNameRegular"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Pak Options|Regular",meta=(EditCondition = "bCustomPakNameRegular"))
 		FString PakNameRegular = TEXT("{VERSION}_{CHUNKNAME}_{PLATFORM}_001_P");
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Pak Options|Regular")
+		bool bCustomPakSaveDirRegular = false;
+	// Can use value: {VERSION} {BASEVERSION} {CHUNKNAME} {PLATFORM} 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Pak Options",meta=(EditCondition = "bCustomPakSaveDirRegular"))
+		FString PakSaveDirRegular = TEXT("{CHUNKNAME}/{PLATFORM}");
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SaveTo")
 		bool bStorageNewRelease = true;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherSettingBase.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherSettingBase.h
@@ -37,15 +37,7 @@ struct HOTPATCHERRUNTIME_API FHotPatcherSettingBase:public FPatcherEntitySetting
     FORCEINLINE virtual bool IsStandaloneMode()const {return bStandaloneMode;}
     FORCEINLINE virtual bool IsSaveConfig()const {return bStorageConfig;}
     FORCEINLINE virtual TArray<FString> GetAdditionalCommandletArgs()const{return AdditionalCommandletArgs;}
-    FORCEINLINE virtual FString GetCombinedAdditionalCommandletArgs()const
-    {
-        FString Result;
-        for(const auto& Option:GetAdditionalCommandletArgs())
-        {
-            Result+=FString::Printf(TEXT("%s "),*Option);
-        }
-        return Result;
-    }
+    virtual FString GetCombinedAdditionalCommandletArgs()const;
 
     FORCEINLINE virtual bool IsForceSkipContent()const{return GetAssetScanConfig().bForceSkipContent;}
     FORCEINLINE virtual TArray<FDirectoryPath> GetForceSkipContentRules()const {return GetAssetScanConfig().ForceSkipContentRules;}

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/TimeRecorder.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/TimeRecorder.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "HotPatcherLog.h"
 
-struct TimeRecorder
+struct HOTPATCHERRUNTIME_API TimeRecorder
 {
     TimeRecorder(const FString& InDisplay=TEXT(""),bool InAuto = true):Display(InDisplay),bAuto(InAuto)
     {

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibAssetManageHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibAssetManageHelper.h
@@ -86,7 +86,9 @@ public:
 	static FAssetPackageData* GetPackageDataByPackageName(const FString& InPackageName);
 	UFUNCTION(BlueprintCallable, Category = "GWorld|Flib|AssetManagerExEx")
 	static bool GetAssetPackageGUID(const FString& InPackageName, FName& OutGUID);
-	
+
+	static FSoftObjectPath CreateSoftObjectPathByPackage(UPackage* Package);
+	static FName GetAssetTypeByPackage(UPackage* Package);
 	static FName GetAssetType(FSoftObjectPath InPackageName);
 	
 	// Combine AssetDependencies Filter repeat asset
@@ -251,6 +253,8 @@ public:
 	static FName GetAssetDataClasses(const FAssetData& Data);
 	static FName GetObjectPathByAssetData(const FAssetData& Data);
 	static bool bIncludeOnlyOnDiskAssets;
+
+	static void UpdateAssetRegistryData(const FString& PackageName);
 };
 
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
@@ -242,5 +242,6 @@ public:
 	static void SetPropertyTransient(UStruct* Struct,const FString& PropertyName,bool bTransient);
 	static FString GetTargetPlatformsCmdLine(const TArray<ETargetPlatform>& Platforms);
 	static FString MergeOptionsAsCmdline(const TArray<FString>& InOptions);
+	static FString GetPlatformsStr(TArray<ETargetPlatform> Platforms);
 };
 

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
@@ -239,6 +239,8 @@ public:
 	}
 
 	static bool IsValidPatchSettings(const FExportPatchSettings* PatchSettings,bool bExternalFilesCheck);
-	
+	static void SetPropertyTransient(UStruct* Struct,const FString& PropertyName,bool bTransient);
+	static FString GetTargetPlatformsCmdLine(const TArray<ETargetPlatform>& Platforms);
+	static FString MergeOptionsAsCmdline(const TArray<FString>& InOptions);
 };
 


### PR DESCRIPTION
1. 优化基础实现、关闭不必要的Log输出
2. 优化对依赖加载材质的额外Shader编译， 支持`NoPostLoadCacheDDC`参数控制（UE4中需要修改引擎才能使用该优化）
3. 优化CookCluster的分配策略
4. 优化Pak文件列表收集
5. 优化资源分析性能
6. 优化模块的可扩展性
7. 修复跨引擎版本的兼容性问题
8. 修复Shipping的C4172 ERROR
9. 修复不支持WP导致的基础包打包错误（`Found mor than one redistered Cook Package Splitter`）
10.  支持`PakSaveDirRegular`，自定义Pak的输出路径
11. 支持PakPreset/CookAndPak以统一的方式执行
12. 支持全局的AllowCookPlatforms

源码版引擎的`NoPostLoadCacheDDC`参数支持需要修改引擎，添加以下`[lipengzha]`中包裹的代码：
>Launcher引擎默认不支持该优化，Cook耗时会慢一些，但对功能无影响。

```cpp
// Engine/Source/Runtime/Engine/Private/Materials/MaterialInstance.cpp
void UMaterialInstance::PostLoad()
{
	// ...
	//++[lipengzha] cmdlet option for disable cook in PostLoad 
	bool bNoPostLoadCacheDDC = FParse::Param(FCommandLine::Get(), TEXT("NoPostLoadCacheDDC"));
	if (!bNoPostLoadCacheDDC && TPM && (TPM->RestrictFormatsToRuntimeOnly() == false))
	//--[lipengzha]
	{
		TArray<ITargetPlatform*> Platforms = TPM->GetActiveTargetPlatforms();
		// Cache for all the shader formats that the cooking target requires
		for (int32 FormatIndex = 0; FormatIndex < Platforms.Num(); FormatIndex++)
		{
			BeginCacheForCookedPlatformData(Platforms[FormatIndex]);
		}
	}
	// ...
}
```
