### PR TITLE
Fix Linux DS build for "Plugins\HotPatcher\Source\HotPatcherRuntime\Private\FlibPakHelper.cpp(6,10): error: non-portable path to file '"HAL/PlatformFileManager.h"'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]"

### DIFF
--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
@@ -3,7 +3,11 @@
 
 #include "FlibPakHelper.h"
 #include "IPlatformFilePak.h"
+#if WITH_UE5
 #include "HAL/PlatformFileManager.h"
+#else
+#include "HAL/PlatformFilemanager.h"
+#endif
 #include "AssetManager/FFileArrayDirectoryVisitor.hpp"
 #include "HotPatcherLog.h"
 #include "FlibAssetManageHelper.h"

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
@@ -3,10 +3,10 @@
 
 #include "FlibPakHelper.h"
 #include "IPlatformFilePak.h"
-#if WITH_UE5
-#include "HAL/PlatformFileManager.h"
-#else
+#if UE_VERSION_OLDER_THAN(5,0,0)
 #include "HAL/PlatformFilemanager.h"
+#else
+#include "HAL/PlatformFileManager.h"
 #endif
 #include "AssetManager/FFileArrayDirectoryVisitor.hpp"
 #include "HotPatcherLog.h"

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
@@ -3,7 +3,7 @@
 
 #include "FlibPakHelper.h"
 #include "IPlatformFilePak.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "AssetManager/FFileArrayDirectoryVisitor.hpp"
 #include "HotPatcherLog.h"
 #include "FlibAssetManageHelper.h"


### PR DESCRIPTION
This is due to the change introduced from engine-side from UE5 start: https://github.com/EpicGames/UnrealEngine/commit/99be00dcdb26416cd7305119e0f144b3fdb9a565

