### PR TITLE
Fix/chunk pak  修复分块功能  并将共有资产 提出到Common分块中

### DIFF
--- a/HotPatcher/HotPatcher.uplugin
+++ b/HotPatcher/HotPatcher.uplugin
@@ -37,7 +37,7 @@
 		},
 		{
 			"Name": "CmdHandler",
-			"Type": "Developer",
+			"Type": "DeveloperTool",
 			"LoadingPhase": "PostConfigInit"
 		}
 	]

--- a/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/HotPatcherCommandlet.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Classes/Commandlets/HotPatcherCommandlet.cpp
@@ -19,7 +19,19 @@ int32 UHotPatcherCommandlet::Main(const FString& Params)
 #if WITH_UE5
 	PRIVATE_GIsRunningCookCommandlet = true;
 #endif
-	
+
+#if WITH_EDITOR&&DEBUG  // 或 #if !UE_BUILD_SHIPPING
+	// 等待调试器附加（调试时去掉或宏屏蔽）
+	UE_LOG(LogHotPatcherCommandlet, Display, TEXT("Waiting for debugger to attach..."));
+	while (!FPlatformMisc::IsDebuggerPresent())
+	{
+		FPlatformProcess::Sleep(0.2f);
+	}
+	UE_LOG(LogHotPatcherCommandlet, Display, TEXT("Debugger attached, continue"));
+#endif	
+
+
+
 	Super::Main(Params);
 
 	FCommandLine::Append(TEXT(" -buildmachine"));

--- a/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
+++ b/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
@@ -196,7 +196,7 @@ public class HotPatcherCore : ModuleRules
 		});
 		PrivateDefinitions.AddRange(new string[]
 		{
-            "DEBUG=0"
+            "DEBUG=1"
         });
     }
 }

--- a/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
+++ b/HotPatcher/Source/HotPatcherCore/HotPatcherCore.Build.cs
@@ -194,5 +194,9 @@ public class HotPatcherCore : ModuleRules
 			"CURRENT_PATCH_ID=0",
 			"REMOTE_VERSION_FILE=\"https://imzlp.com/opensource/version.json\""
 		});
-	}
+		PrivateDefinitions.AddRange(new string[]
+		{
+            "DEBUG=0"
+        });
+    }
 }

--- a/HotPatcher/Source/HotPatcherCore/Private/Cooker/PackageWriter/HotPatcherPackageWriter.h
+++ b/HotPatcher/Source/HotPatcherCore/Private/Cooker/PackageWriter/HotPatcherPackageWriter.h
@@ -5,6 +5,7 @@
 #if WITH_PACKAGE_CONTEXT && ENGINE_MAJOR_VERSION > 4
 #include "Serialization/PackageWriter.h"
 #include "PackageWriterToSharedBuffer.h"
+#include "AssetRegistry/AssetRegistryState.h"
 
 class FHotPatcherPackageWriter:public TPackageWriterToSharedBuffer<ICookedPackageWriter>
 {

--- a/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
@@ -786,13 +786,9 @@ namespace PatchWorker
 		for (const auto& Chunk : Context.PakChunks)
 		{
 			TimeRecorder ChunkScanTR(FString::Printf(TEXT("Scan Chunk %s for assignment"), *Chunk.ChunkName));
-            // Use explicit-only export here (disable dependency analysis) so we get
-            // the authoritative list of assets *explicitly* assigned to this chunk.
-            // Relying on dependency-expanded results (AllLoadedPackageSet) causes
-            // shared dependency assets (engine/plugins) to appear in multiple
-            // chunk scans and be mis-classified as common.
+          
             FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
-                TEXT(""), TEXT(""), TEXT(""),
+				TEXT(""), TEXT(""), TEXT(""),
                 Chunk,
                 false,
                 false, // explicit-only, do NOT analysis filter dependencies here
@@ -808,19 +804,33 @@ namespace PatchWorker
 			}
 		}
 
-		//在分块下的所有引用
+        // Build a set of diff package names (Add + Modify) so we only assign changed assets to chunks
+        TSet<FString> DiffPackageNames;
+        {
+            const TArray<FAssetDetail> AddDetails = Context.VersionDiff.AssetDiffInfo.AddAssetDependInfo.GetAssetDetails();
+            const TArray<FAssetDetail> ModDetails = Context.VersionDiff.AssetDiffInfo.ModifyAssetDependInfo.GetAssetDetails();
+            for (const auto& D : AddDetails)
+            {
+                DiffPackageNames.Add(UFlibAssetManageHelper::PackagePathToLongPackageName(D.PackagePath.ToString()));
+            }
+            for (const auto& D : ModDetails)
+            {
+                DiffPackageNames.Add(UFlibAssetManageHelper::PackagePathToLongPackageName(D.PackagePath.ToString()));
+            }
+        }
+
+		//在分块下的所有引用（基于Diff）
 		TMap<FString, TSet<FString>> ChunkPackagesAll;
 		for (const auto& Chunk : Context.PakChunks)
 		{
-			FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
-				TEXT(""), TEXT(""), TEXT(""),
-				Chunk,
-				false,
-				true,
-				Context.GetSettingObject()->GetHashCalculator()
-			);
+			FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::DiffAssetByChunk(
+                Context.VersionDiff,
+                Chunk,
+                true,
+                Context.GetSettingObject()->GetHashCalculator()
+            );
 
-			TSet<FString>& PkgSet = ChunkPackagesAll.FindOrAdd(Chunk.ChunkName);
+            TSet<FString>& PkgSet = ChunkPackagesAll.FindOrAdd(Chunk.ChunkName);
 			for (const auto& Detail : ChunkVersion.AssetInfo.GetAssetDetails())
 			{
 				FString PkgName = UFlibAssetManageHelper::PackagePathToLongPackageName(Detail.PackagePath.ToString());
@@ -828,9 +838,9 @@ namespace PatchWorker
 				if (!PackageToAssetDetail.Contains(PkgName))
 				{
 					PackageToAssetDetail.Add(PkgName, Detail);
-				}
-			}
-		}
+                }
+            }
+        }
 
 		//所有过滤分块下取补集
 		TMap<FString, TSet<FString>> ChunkDifferencePackages;
@@ -892,15 +902,43 @@ namespace PatchWorker
 		for (const auto& Chunk : Context.PakChunks)
 		{
 			FChunkAssetDescribe Desc;
+			const TArray<FAssetDetail>& DiffAddAssets = Context.VersionDiff.AssetDiffInfo.AddAssetDependInfo.GetAssetDetails();
+			const TArray<FAssetDetail>& DiffModifyAssets = Context.VersionDiff.AssetDiffInfo.ModifyAssetDependInfo.GetAssetDetails();
 
-			// 添加显式分块资产（不包含公共资产）
+			TMap<FString, FAssetDetail> DiffAddMap;
+			TMap<FString, FAssetDetail> DiffModifyMap;
+			for (const auto& Asset : DiffAddAssets)
+			{
+				FString LongPackageName = UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString());
+				if (DiffPackageNames.Contains(LongPackageName))
+				{
+					DiffAddMap.Add(LongPackageName, Asset);
+				}
+			}
+			for (const auto& Asset : DiffModifyAssets)
+			{
+				FString LongPackageName = UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString());
+				if (DiffPackageNames.Contains(LongPackageName))
+				{
+					DiffModifyMap.Add(LongPackageName, Asset);
+				}
+			}
+
+			// 添加显式分块资产（不包含公共资产，且仅来自diff）
 			const TSet<FString>& ChunkPkgs = ChunkOwnedPackages.FindRef(Chunk.ChunkName);
 			for (const auto& PkgName : ChunkPkgs)
 			{
-				Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);	
+				if (DiffAddMap.Contains(PkgName))
+				{
+					Desc.AddAssets.AddAssetsDetail(DiffAddMap[PkgName]);
+				}
+				else if (DiffModifyMap.Contains(PkgName))
+				{
+					Desc.ModifyAssets.AddAssetsDetail(DiffModifyMap[PkgName]);
+				}
 			}
 
-			Desc.Assets = Desc.AddAssets;
+			Desc.Assets = UFlibAssetManageHelper::CombineAssetDependencies(Desc.AddAssets, Desc.ModifyAssets);
 
 			// Collect extern files per-platform (use existing helper)
 			for (auto Platform : AllPlatforms)
@@ -922,15 +960,31 @@ namespace PatchWorker
 		if (CommonDifferencePackages.Num() > 0)
 		{
 			Context.CommonChunkDescribe = FChunkAssetDescribe();
+			const TArray<FAssetDetail>& DiffAddAssets = Context.VersionDiff.AssetDiffInfo.AddAssetDependInfo.GetAssetDetails();
+			const TArray<FAssetDetail>& DiffModifyAssets = Context.VersionDiff.AssetDiffInfo.ModifyAssetDependInfo.GetAssetDetails();
+			TMap<FString, FAssetDetail> DiffAddMap;
+			TMap<FString, FAssetDetail> DiffModifyMap;
+			for (const auto& Asset : DiffAddAssets)
+			{
+				DiffAddMap.Add(UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString()), Asset);
+			}
+			for (const auto& Asset : DiffModifyAssets)
+			{
+				DiffModifyMap.Add(UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString()), Asset);
+			}
 			for (const auto& PkgName : CommonDifferencePackages)
 			{
-				if (PackageToAssetDetail.Contains(PkgName))
+				if (DiffAddMap.Contains(PkgName))
 				{
-					Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
+					Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(DiffAddMap[PkgName]);
+				}
+				else if (DiffModifyMap.Contains(PkgName))
+				{
+					Context.CommonChunkDescribe.ModifyAssets.AddAssetsDetail(DiffModifyMap[PkgName]);
 				}
 			}
 
-			Context.CommonChunkDescribe.Assets = Context.CommonChunkDescribe.AddAssets;
+			Context.CommonChunkDescribe.Assets = UFlibAssetManageHelper::CombineAssetDependencies(Context.CommonChunkDescribe.AddAssets, Context.CommonChunkDescribe.ModifyAssets);
 
 			if (Context.CommonChunkDescribe.HasValidAssets())
 			{

--- a/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
@@ -85,6 +85,8 @@ namespace PatchWorker
 	bool CookPatchAssetsWorker(FHotPatcherPatchContext& Context);
 	// setup 7.1
 	bool PostCookPatchAssets(FHotPatcherPatchContext& Context);
+	// setup 7.15
+	bool ResolveCommonChunkWorker(FHotPatcherPatchContext& Context);
 
 	// setup 7.1
 	bool PatchAssetRegistryWorker(FHotPatcherPatchContext& Context);
@@ -213,6 +215,7 @@ void UPatcherProxy::Init(FPatcherEntitySettingBase* InSetting)
 	ADD_PATCH_WORKER(PatchWorker::CookPatchAssetsWorker);
 	// cook finished
 	ADD_PATCH_WORKER(PatchWorker::PostCookPatchAssets);
+	ADD_PATCH_WORKER(PatchWorker::ResolveCommonChunkWorker);
 	ADD_PATCH_WORKER(PatchWorker::PatchAssetRegistryWorker);
 	ADD_PATCH_WORKER(PatchWorker::GenerateGlobalAssetRegistryManifest);
 	ADD_PATCH_WORKER(PatchWorker::GeneratePakProxysWorker);
@@ -491,15 +494,18 @@ namespace PatchWorker
 					ChunkCheckerMsg(TEXT("External Files"), AllUnselectedExFiles);
 					ChunkCheckerMsg(TEXT("Internal Files(Patch & Chunk setting not match)"), UnSelectedInternalFiles);
 
-					if (!TotalMsg.IsEmpty())
-					{
-						Context.OnShowMsg.Broadcast(FString::Printf(TEXT("Unselect in Chunk:\n%s"), *TotalMsg));
-						return false;
-					}
-					else
-					{
-						Context.OnShowMsg.Broadcast(TEXT(""));
-					}
+				if (!TotalMsg.IsEmpty())
+				{
+					// warn and continue: explicit filters may be empty in diff-mode; do not abort the whole export
+					FString WarnMsg = FString::Printf(TEXT("Unselect in Chunk:\n%s"), *TotalMsg);
+					UE_LOG(LogHotPatcher, Warning, TEXT("%s"), *WarnMsg);
+					Context.OnShowMsg.Broadcast(WarnMsg);
+					// continue rather than returning false to allow empty chunk filters in diff scenarios
+				}
+				else
+				{
+					Context.OnShowMsg.Broadcast(TEXT(""));
+				}
 				}
 			}
 		}
@@ -580,6 +586,37 @@ namespace PatchWorker
 		
 		for(const auto& PlatformName :Context.GetSettingObject()->GetPakTargetPlatformNames())
 		{
+			// Build explicit-only package sets for each chunk once per export.
+			// Purpose: ensure when we expand dependencies for a chunk we never
+			// include packages that are explicitly claimed by other chunks' filters.
+			// This enforces the rule: a chunk MUST NOT contain assets matched by
+			// another chunk's include-filters.
+			TMap<FString, TSet<FString>> ChunkExplicitPackages;
+			TMap<FString, FAssetDetail> ExplicitPackageToDetail;
+			if (Context.GetSettingObject()->IsEnableChunk() && Context.PakChunks.Num() > 1)
+			{
+				for (const auto& C : Context.PakChunks)
+				{
+					// export explicit-only list for the chunk (do NOT analysis filter dependencies)
+					FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
+						TEXT(""), TEXT(""), TEXT(""),
+						C,
+						false,
+						false,
+						Context.GetSettingObject()->GetHashCalculator()
+					);
+					TSet<FString>& PkgSet = ChunkExplicitPackages.FindOrAdd(C.ChunkName);
+					for (const auto& Detail : ChunkVersion.AssetInfo.GetAssetDetails())
+					{
+						FString PkgName = UFlibAssetManageHelper::PackagePathToLongPackageName(Detail.PackagePath.ToString());
+						PkgSet.Add(PkgName);
+						if (!ExplicitPackageToDetail.Contains(PkgName))
+						{
+							ExplicitPackageToDetail.Add(PkgName, Detail);
+						}
+					}
+				}
+			}
 			for(auto& Chunk:Context.PakChunks)
 			{
 				TimeRecorder CookPlatformChunkAssetsTotalTR(FString::Printf(TEXT("Cook Chunk %s as %s Total time:"),*Chunk.ChunkName,*PlatformName));
@@ -611,6 +648,7 @@ namespace PatchWorker
 								if(ShadersClasses.Contains(Asset.AssetType)){ AllShaderAssets.Add(Asset);}
 							}
 						}
+						//准备Cook资产
 						FTrackPackageAction TrackChunkPackageAction(Context,Chunk,TArray<ETargetPlatform>{Platform});
 						FSingleCookerSettings EmptySetting;
 						EmptySetting.MissionID = 0;
@@ -710,14 +748,258 @@ namespace PatchWorker
 							}
 						}
 #endif
+							//添加外部文件
+							for(const auto& ExternalFileName:ChunkAssetsDescrible.GetExFilesByPlatform(Platform))
+							{
+								Context.AddExternalFile(PlatformName,Chunk.ChunkName,ExternalFileName);
+							}
+						
 					}
+
+
+
 				}
 			}
 		}
 
 		return true;
 	};
-	
+
+	// setup 7.15
+	bool ResolveCommonChunkWorker(FHotPatcherPatchContext& Context)
+	{
+		SCOPED_NAMED_EVENT_TEXT("ResolveCommonChunkWorker",FColor::Red);
+		/*
+		Purpose and algorithm (enforced rules):
+		1) For each chunk collect TWO views:
+		   - explicitSet: assets directly matched by the chunk's include-filters (explicit-only scan)
+		   - depExpandedSet: assets required by the chunk including recursive dependencies (dependency-expanded)
+		2) Guarantee: depExpandedSet for a chunk MUST NOT contain assets that are explicitly matched by any other chunk's filters.
+		   To enforce this we subtract the union of other chunks' explicitSet from this chunk's depExpandedSet.
+		3) Ownership decision:
+		   - If an asset is explicit in one or more chunks -> assign to single owner by priority/tiebreak.
+		   - If an asset is not explicit anywhere but appears in >=2 depExpanded sets -> place into Common.
+		   - If asset appears in exactly one depExpanded (after subtraction) -> assign to that chunk.
+		4) We only consider project (Game) module assets for Common to avoid classifying engine/plugin assets as shared.
+		
+		Notes:
+		- We use explicit-only scans to determine authoritative ownership and then expand dependencies per chunk
+		  while excluding other chunks' explicit assets to prevent ownership leakage.
+		- Empty explicit sets are WARNed (not fatal) because diff-mode can legitimately produce empty chunk filters.
+		*/
+		if (!Context.GetSettingObject()->IsEnableChunk() || Context.PakChunks.Num() <= 1)
+		{
+			return true;
+		}
+
+		TimeRecorder ResolveCommonTR(TEXT("Resolve Common Chunk assets"));
+
+		TMap<FString, TSet<FString>> ChunkOwnedPackages;
+		TMap<FString, FAssetDetail> PackageToAssetDetail;
+
+		for (const auto& Chunk : Context.PakChunks)
+		{
+			TimeRecorder ChunkScanTR(FString::Printf(TEXT("Scan Chunk %s for assignment"), *Chunk.ChunkName));
+            // Use explicit-only export here (disable dependency analysis) so we get
+            // the authoritative list of assets *explicitly* assigned to this chunk.
+            // Relying on dependency-expanded results (AllLoadedPackageSet) causes
+            // shared dependency assets (engine/plugins) to appear in multiple
+            // chunk scans and be mis-classified as common.
+            FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
+                TEXT(""), TEXT(""), TEXT(""),
+                Chunk,
+                false,
+                false, // explicit-only, do NOT analysis filter dependencies here
+                Context.GetSettingObject()->GetHashCalculator()
+            );
+
+			TSet<FString>& PkgSet = ChunkOwnedPackages.FindOrAdd(Chunk.ChunkName);
+			for (const auto& Detail : ChunkVersion.AssetInfo.GetAssetDetails())
+			{
+				FString PkgName = UFlibAssetManageHelper::PackagePathToLongPackageName(Detail.PackagePath.ToString());
+				PkgSet.Add(PkgName);
+				if (!PackageToAssetDetail.Contains(PkgName))
+				{
+					PackageToAssetDetail.Add(PkgName, Detail);
+				}
+			}
+		}
+
+        // Build owners map from explicit sets
+        TMap<FString, TSet<FString>> PackageOwners;
+        for (const auto& Pair : ChunkOwnedPackages)
+        {
+            for (const auto& PkgName : Pair.Value)
+            {
+                PackageOwners.FindOrAdd(PkgName).Add(Pair.Key);
+            }
+        }
+
+        // Collect dep-expanded package sets per chunk (use CollectFChunkAssetsDescribeByChunk)
+        TMap<FString, TSet<FString>> ChunkDepExpandedPkgs;
+        TMap<FString, TMap<FString, FAssetDetail>> ChunkDepDetailMap; // chunk -> (longpkg -> detail)
+        TArray<ETargetPlatform> AllPlatforms;
+        Context.VersionDiff.PlatformExternDiffInfo.GetKeys(AllPlatforms);
+
+        for (const auto& Chunk : Context.PakChunks)
+        {
+            FChunkAssetDescribe DepDesc = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
+                Context.GetSettingObject(), Context.VersionDiff, Chunk, TArray<ETargetPlatform>{ETargetPlatform::AllPlatforms}
+            );
+            TSet<FString>& DepSet = ChunkDepExpandedPkgs.FindOrAdd(Chunk.ChunkName);
+            TMap<FString, FAssetDetail>& DepDetailMap = ChunkDepDetailMap.FindOrAdd(Chunk.ChunkName);
+            for (const auto& Asset : DepDesc.Assets.GetAssetDetails())
+            {
+                FString LongPkg = UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString());
+                DepSet.Add(LongPkg);
+                if (!DepDetailMap.Contains(LongPkg))
+                {
+                    DepDetailMap.Add(LongPkg, Asset);
+                }
+            }
+        }
+
+        // Build initial CommonPackages from explicit multi-owners (only Game module)
+        TSet<FString> CommonPackages;
+        for (const auto& Pair : PackageOwners)
+        {
+            FString BelongModule = UFlibAssetManageHelper::GetAssetBelongModuleName(Pair.Key);
+            if (Pair.Value.Num() >= 2 && BelongModule.Equals(TEXT("Game"), ESearchCase::IgnoreCase))
+            {
+                CommonPackages.Add(Pair.Key);
+            }
+        }
+
+        // For dep-only packages (not explicit anywhere), if they appear in >=2 chunk dep-expanded sets -> Common
+        TMap<FString, int32> DepPkgCounter;
+        for (const auto& Pair : ChunkDepExpandedPkgs)
+        {
+            for (const auto& Pkg : Pair.Value)
+            {
+                if (!PackageOwners.Contains(Pkg))
+                {
+                    DepPkgCounter.FindOrAdd(Pkg) += 1;
+                }
+            }
+        }
+        for (const auto& Pair : DepPkgCounter)
+        {
+            if (Pair.Value >= 2)
+            {
+                FString BelongModule = UFlibAssetManageHelper::GetAssetBelongModuleName(Pair.Key);
+                if (BelongModule.Equals(TEXT("Game"), ESearchCase::IgnoreCase))
+                {
+                    CommonPackages.Add(Pair.Key);
+                }
+            }
+        }
+
+        // Now build final chunk describes: explicit-owned (single-owner) + dep-expanded (after excluding other chunk explicit pkgs and commons)
+        for (const auto& Chunk : Context.PakChunks)
+        {
+            FChunkAssetDescribe Desc;
+
+            // Add explicit-only packages that belong to this chunk (skip commons)
+            const TSet<FString>& ChunkPkgs = ChunkOwnedPackages.FindRef(Chunk.ChunkName);
+            for (const auto& PkgName : ChunkPkgs)
+            {
+                if (CommonPackages.Contains(PkgName))
+                {
+                    continue;
+                }
+                if (PackageToAssetDetail.Contains(PkgName))
+                {
+                    Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
+                }
+            }
+
+            // Build union of explicit packages from other chunks to exclude
+            TSet<FString> OtherChunkExplicitPkgs;
+            for (const auto& Pair : ChunkOwnedPackages)
+            {
+                if (Pair.Key == Chunk.ChunkName) continue;
+                OtherChunkExplicitPkgs.Append(Pair.Value);
+            }
+
+            // Add dep-expanded assets for this chunk, excluding other-chunk explicit pkgs and commons
+            const TSet<FString>& DepSet = ChunkDepExpandedPkgs.FindRef(Chunk.ChunkName);
+            const TMap<FString, FAssetDetail>& DepDetailMap = ChunkDepDetailMap.FindRef(Chunk.ChunkName);
+            for (const auto& LongPkg : DepSet)
+            {
+                if (OtherChunkExplicitPkgs.Contains(LongPkg))
+                {
+                    UE_LOG(LogHotPatcher, Display, TEXT("Exclude %s from chunk %s because it's explicitly claimed by another chunk's filter"), *LongPkg, *Chunk.ChunkName);
+                    continue;
+                }
+                if (CommonPackages.Contains(LongPkg))
+                {
+                    continue;
+                }
+
+                // Prefer explicit detail if available, else use dependency detail
+                if (PackageToAssetDetail.Contains(LongPkg))
+                {
+                    Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[LongPkg]);
+                }
+                else if (DepDetailMap.Contains(LongPkg))
+                {
+                    Desc.AddAssets.AddAssetsDetail(DepDetailMap[LongPkg]);
+                }
+            }
+
+            Desc.Assets = Desc.AddAssets;
+
+            // Collect extern files per-platform (use existing helper)
+            for (auto Platform : AllPlatforms)
+            {
+                FPlatformExternFiles PlatformFiles;
+                PlatformFiles.Platform = Platform;
+                PlatformFiles.ExternFiles = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
+                    Context.GetSettingObject(), Context.VersionDiff, Chunk, TArray<ETargetPlatform>{Platform}
+                ).GetExFilesByPlatform(Platform);
+                Desc.AllPlatformExFiles.Add(Platform, PlatformFiles);
+            }
+
+            Desc.InternalFiles = Chunk.InternalFiles;
+            Context.ChunkDescribeCache.Add(Chunk.ChunkName, Desc);
+        }
+
+        // Build Common chunk describe from CommonPackages
+        if (CommonPackages.Num() > 0)
+        {
+            Context.CommonChunkDescribe = FChunkAssetDescribe();
+            for (const auto& PkgName : CommonPackages)
+            {
+                if (PackageToAssetDetail.Contains(PkgName))
+                {
+                    Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
+                }
+                else
+                {
+                    // try to find detail from any chunk's dep detail map
+                    for (const auto& Pair : ChunkDepDetailMap)
+                    {
+                        if (Pair.Value.Contains(PkgName))
+                        {
+                            Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(Pair.Value[PkgName]);
+                            break;
+                        }
+                    }
+                }
+            }
+            Context.CommonChunkDescribe.Assets = Context.CommonChunkDescribe.AddAssets;
+
+            if (Context.CommonChunkDescribe.HasValidAssets())
+            {
+                Context.PakChunks.Add(Context.CommonChunkDescribe.AsChunkInfo(Context.CommonChunkName));
+                Context.ChunkDescribeCache.Add(Context.CommonChunkName, Context.CommonChunkDescribe);
+                UE_LOG(LogHotPatcher, Display, TEXT("Resolved Common chunk with %d shared assets"), CommonPackages.Num());
+            }
+        }
+
+		return true;
+	};
+
 	bool PatchAssetRegistryWorker(FHotPatcherPatchContext& Context)
 	{
 		SCOPED_NAMED_EVENT_TEXT("PatchAssetRegistryWorker",FColor::Red);
@@ -727,11 +1009,19 @@ namespace PatchWorker
 			{
 				ETargetPlatform Platform;
 				THotPatcherTemplateHelper::GetEnumValueByName(PlatformName,Platform);
-				FChunkAssetDescribe ChunkAssetsDescrible = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
-					Context.GetSettingObject(),
-					Context.VersionDiff,
-					Chunk, TArray<ETargetPlatform>{Platform}
-				);
+				FChunkAssetDescribe ChunkAssetsDescrible;
+				if (Context.ChunkDescribeCache.Contains(Chunk.ChunkName))
+				{
+					ChunkAssetsDescrible = *Context.ChunkDescribeCache.Find(Chunk.ChunkName);
+				}
+				else
+				{
+					ChunkAssetsDescrible = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
+						Context.GetSettingObject(),
+						Context.VersionDiff,
+						Chunk, TArray<ETargetPlatform>{Platform}
+					);
+				}
 				const TArray<FAssetDetail>& ChunkAssets = ChunkAssetsDescrible.Assets.GetAssetDetails();
 				
 				if(Context.GetSettingObject()->GetSerializeAssetRegistryOptions().bSerializeAssetRegistry)
@@ -957,12 +1247,29 @@ namespace PatchWorker
 				TArray<FPakCommand> ChunkPakListCommands;
 				{
 					TimeRecorder CookAssetsTR(FString::Printf(TEXT("CollectPakCommandByChunk Platform:%s ChunkName:%s."),*PlatformName,*Chunk.ChunkName));
-					ChunkPakListCommands= UFlibPatchParserHelper::CollectPakCommandByChunk(
-						Context.VersionDiff,
-						Chunk,
-						PlatformName,
-						Context.GetSettingObject()
-					);
+					if (Context.ChunkDescribeCache.Contains(Chunk.ChunkName))
+					{
+						FPatchVersionDiff CachedDiff;
+						FChunkAssetDescribe& CachedDesc = *Context.ChunkDescribeCache.Find(Chunk.ChunkName);
+						CachedDiff.AssetDiffInfo.AddAssetDependInfo = CachedDesc.AddAssets;
+						CachedDiff.AssetDiffInfo.ModifyAssetDependInfo = CachedDesc.ModifyAssets;
+						CachedDiff.PlatformExternDiffInfo = Context.VersionDiff.PlatformExternDiffInfo;
+						ChunkPakListCommands = UFlibPatchParserHelper::CollectPakCommandByChunk(
+							CachedDiff,
+							Chunk,
+							PlatformName,
+							Context.GetSettingObject()
+						);
+					}
+					else
+					{
+						ChunkPakListCommands = UFlibPatchParserHelper::CollectPakCommandByChunk(
+							Context.VersionDiff,
+							Chunk,
+							PlatformName,
+							Context.GetSettingObject()
+						);
+					}
 				}
 				
 				if(Context.PatchProxy)

--- a/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/CreatePatch/PatcherProxy.cpp
@@ -769,24 +769,7 @@ namespace PatchWorker
 	bool ResolveCommonChunkWorker(FHotPatcherPatchContext& Context)
 	{
 		SCOPED_NAMED_EVENT_TEXT("ResolveCommonChunkWorker",FColor::Red);
-		/*
-		Purpose and algorithm (enforced rules):
-		1) For each chunk collect TWO views:
-		   - explicitSet: assets directly matched by the chunk's include-filters (explicit-only scan)
-		   - depExpandedSet: assets required by the chunk including recursive dependencies (dependency-expanded)
-		2) Guarantee: depExpandedSet for a chunk MUST NOT contain assets that are explicitly matched by any other chunk's filters.
-		   To enforce this we subtract the union of other chunks' explicitSet from this chunk's depExpandedSet.
-		3) Ownership decision:
-		   - If an asset is explicit in one or more chunks -> assign to single owner by priority/tiebreak.
-		   - If an asset is not explicit anywhere but appears in >=2 depExpanded sets -> place into Common.
-		   - If asset appears in exactly one depExpanded (after subtraction) -> assign to that chunk.
-		4) We only consider project (Game) module assets for Common to avoid classifying engine/plugin assets as shared.
-		
-		Notes:
-		- We use explicit-only scans to determine authoritative ownership and then expand dependencies per chunk
-		  while excluding other chunks' explicit assets to prevent ownership leakage.
-		- Empty explicit sets are WARNed (not fatal) because diff-mode can legitimately produce empty chunk filters.
-		*/
+	
 		if (!Context.GetSettingObject()->IsEnableChunk() || Context.PakChunks.Num() <= 1)
 		{
 			return true;
@@ -794,9 +777,12 @@ namespace PatchWorker
 
 		TimeRecorder ResolveCommonTR(TEXT("Resolve Common Chunk assets"));
 
+		//分块过滤器下的资产
 		TMap<FString, TSet<FString>> ChunkOwnedPackages;
+		
+		//所有分块过滤器下的资产依赖的详情 用于后续添加到分块描述中
 		TMap<FString, FAssetDetail> PackageToAssetDetail;
-
+		//获得分块 所有依赖的引用
 		for (const auto& Chunk : Context.PakChunks)
 		{
 			TimeRecorder ChunkScanTR(FString::Printf(TEXT("Scan Chunk %s for assignment"), *Chunk.ChunkName));
@@ -818,6 +804,27 @@ namespace PatchWorker
 			{
 				FString PkgName = UFlibAssetManageHelper::PackagePathToLongPackageName(Detail.PackagePath.ToString());
 				PkgSet.Add(PkgName);
+				
+			}
+		}
+
+		//在分块下的所有引用
+		TMap<FString, TSet<FString>> ChunkPackagesAll;
+		for (const auto& Chunk : Context.PakChunks)
+		{
+			FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
+				TEXT(""), TEXT(""), TEXT(""),
+				Chunk,
+				false,
+				true,
+				Context.GetSettingObject()->GetHashCalculator()
+			);
+
+			TSet<FString>& PkgSet = ChunkPackagesAll.FindOrAdd(Chunk.ChunkName);
+			for (const auto& Detail : ChunkVersion.AssetInfo.GetAssetDetails())
+			{
+				FString PkgName = UFlibAssetManageHelper::PackagePathToLongPackageName(Detail.PackagePath.ToString());
+				PkgSet.Add(PkgName);
 				if (!PackageToAssetDetail.Contains(PkgName))
 				{
 					PackageToAssetDetail.Add(PkgName, Detail);
@@ -825,177 +832,115 @@ namespace PatchWorker
 			}
 		}
 
-        // Build owners map from explicit sets
-        TMap<FString, TSet<FString>> PackageOwners;
-        for (const auto& Pair : ChunkOwnedPackages)
-        {
-            for (const auto& PkgName : Pair.Value)
-            {
-                PackageOwners.FindOrAdd(PkgName).Add(Pair.Key);
-            }
-        }
+		//所有过滤分块下取补集
+		TMap<FString, TSet<FString>> ChunkDifferencePackages;
+		for (const auto& Pair : ChunkPackagesAll)
+		{
+			auto& DiffSet = ChunkDifferencePackages.FindOrAdd(Pair.Key);
+			TSet<FString> ChunksDiffe = Pair.Value;
+			for (const auto& OwnedPair : ChunkOwnedPackages)
+			{
+				ChunksDiffe = ChunksDiffe.Difference(OwnedPair.Value);
+			}	
+			DiffSet = MoveTemp(ChunksDiffe);
+			
+		}
 
-        // Collect dep-expanded package sets per chunk (use CollectFChunkAssetsDescribeByChunk)
-        TMap<FString, TSet<FString>> ChunkDepExpandedPkgs;
-        TMap<FString, TMap<FString, FAssetDetail>> ChunkDepDetailMap; // chunk -> (longpkg -> detail)
-        TArray<ETargetPlatform> AllPlatforms;
-        Context.VersionDiff.PlatformExternDiffInfo.GetKeys(AllPlatforms);
+		//剔除补集下 公共部分  > 2
+		TSet<FString> CommonDifferencePackages;
+		TSet<FString> TempAllDifferencePackages;
+		
+		//收集公共部分
+		TSet<FString> TempSet;
+		for (auto& Pair : ChunkDifferencePackages)
+		{
+			for (const auto& Pkg : Pair.Value)
+			{
+				if (TempAllDifferencePackages.Contains(Pkg))
+				{
+					CommonDifferencePackages.Add(Pkg);
+					TempSet.Add(Pkg);
+					UE_LOG(LogHotPatcher, Log, TEXT("CommonPackages:%d  %s"), CommonDifferencePackages.Num(), *Pkg);					
+				}
+				else
+				{
+					TempAllDifferencePackages.Add(Pkg);
+				}
+			}
+		}
 
-        for (const auto& Chunk : Context.PakChunks)
-        {
-            FChunkAssetDescribe DepDesc = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
-                Context.GetSettingObject(), Context.VersionDiff, Chunk, TArray<ETargetPlatform>{ETargetPlatform::AllPlatforms}
-            );
-            TSet<FString>& DepSet = ChunkDepExpandedPkgs.FindOrAdd(Chunk.ChunkName);
-            TMap<FString, FAssetDetail>& DepDetailMap = ChunkDepDetailMap.FindOrAdd(Chunk.ChunkName);
-            for (const auto& Asset : DepDesc.Assets.GetAssetDetails())
-            {
-                FString LongPkg = UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString());
-                DepSet.Add(LongPkg);
-                if (!DepDetailMap.Contains(LongPkg))
-                {
-                    DepDetailMap.Add(LongPkg, Asset);
-                }
-            }
-        }
+		//剔除公共部分
+		for (auto& Pair : ChunkDifferencePackages)
+		{
+			Pair.Value = Pair.Value.Difference(TempSet);	
+		}
 
-        // Build initial CommonPackages from explicit multi-owners (only Game module)
-        TSet<FString> CommonPackages;
-        for (const auto& Pair : PackageOwners)
-        {
-            FString BelongModule = UFlibAssetManageHelper::GetAssetBelongModuleName(Pair.Key);
-            if (Pair.Value.Num() >= 2 && BelongModule.Equals(TEXT("Game"), ESearchCase::IgnoreCase))
-            {
-                CommonPackages.Add(Pair.Key);
-            }
-        }
+		TempSet.Empty();
+		TempAllDifferencePackages.Empty();
 
-        // For dep-only packages (not explicit anywhere), if they appear in >=2 chunk dep-expanded sets -> Common
-        TMap<FString, int32> DepPkgCounter;
-        for (const auto& Pair : ChunkDepExpandedPkgs)
-        {
-            for (const auto& Pkg : Pair.Value)
-            {
-                if (!PackageOwners.Contains(Pkg))
-                {
-                    DepPkgCounter.FindOrAdd(Pkg) += 1;
-                }
-            }
-        }
-        for (const auto& Pair : DepPkgCounter)
-        {
-            if (Pair.Value >= 2)
-            {
-                FString BelongModule = UFlibAssetManageHelper::GetAssetBelongModuleName(Pair.Key);
-                if (BelongModule.Equals(TEXT("Game"), ESearchCase::IgnoreCase))
-                {
-                    CommonPackages.Add(Pair.Key);
-                }
-            }
-        }
+		//将剔除公共部分 每个分块剩下补集 添加到分块的资产列表中
+		for (auto& Pair : ChunkOwnedPackages)
+		{
+			auto DiffSet = ChunkDifferencePackages.Find(Pair.Key);
+			Pair.Value.Append(*DiffSet);
+		}
 
-        // Now build final chunk describes: explicit-owned (single-owner) + dep-expanded (after excluding other chunk explicit pkgs and commons)
-        for (const auto& Chunk : Context.PakChunks)
-        {
-            FChunkAssetDescribe Desc;
 
-            // Add explicit-only packages that belong to this chunk (skip commons)
-            const TSet<FString>& ChunkPkgs = ChunkOwnedPackages.FindRef(Chunk.ChunkName);
-            for (const auto& PkgName : ChunkPkgs)
-            {
-                if (CommonPackages.Contains(PkgName))
-                {
-                    continue;
-                }
-                if (PackageToAssetDetail.Contains(PkgName))
-                {
-                    Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
-                }
-            }
+		TArray<ETargetPlatform> AllPlatforms;
+		Context.VersionDiff.PlatformExternDiffInfo.GetKeys(AllPlatforms);
 
-            // Build union of explicit packages from other chunks to exclude
-            TSet<FString> OtherChunkExplicitPkgs;
-            for (const auto& Pair : ChunkOwnedPackages)
-            {
-                if (Pair.Key == Chunk.ChunkName) continue;
-                OtherChunkExplicitPkgs.Append(Pair.Value);
-            }
+		for (const auto& Chunk : Context.PakChunks)
+		{
+			FChunkAssetDescribe Desc;
 
-            // Add dep-expanded assets for this chunk, excluding other-chunk explicit pkgs and commons
-            const TSet<FString>& DepSet = ChunkDepExpandedPkgs.FindRef(Chunk.ChunkName);
-            const TMap<FString, FAssetDetail>& DepDetailMap = ChunkDepDetailMap.FindRef(Chunk.ChunkName);
-            for (const auto& LongPkg : DepSet)
-            {
-                if (OtherChunkExplicitPkgs.Contains(LongPkg))
-                {
-                    UE_LOG(LogHotPatcher, Display, TEXT("Exclude %s from chunk %s because it's explicitly claimed by another chunk's filter"), *LongPkg, *Chunk.ChunkName);
-                    continue;
-                }
-                if (CommonPackages.Contains(LongPkg))
-                {
-                    continue;
-                }
+			// 添加显式分块资产（不包含公共资产）
+			const TSet<FString>& ChunkPkgs = ChunkOwnedPackages.FindRef(Chunk.ChunkName);
+			for (const auto& PkgName : ChunkPkgs)
+			{
+				Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);	
+			}
 
-                // Prefer explicit detail if available, else use dependency detail
-                if (PackageToAssetDetail.Contains(LongPkg))
-                {
-                    Desc.AddAssets.AddAssetsDetail(PackageToAssetDetail[LongPkg]);
-                }
-                else if (DepDetailMap.Contains(LongPkg))
-                {
-                    Desc.AddAssets.AddAssetsDetail(DepDetailMap[LongPkg]);
-                }
-            }
+			Desc.Assets = Desc.AddAssets;
 
-            Desc.Assets = Desc.AddAssets;
+			// Collect extern files per-platform (use existing helper)
+			for (auto Platform : AllPlatforms)
+			{
 
-            // Collect extern files per-platform (use existing helper)
-            for (auto Platform : AllPlatforms)
-            {
-                FPlatformExternFiles PlatformFiles;
-                PlatformFiles.Platform = Platform;
-                PlatformFiles.ExternFiles = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
-                    Context.GetSettingObject(), Context.VersionDiff, Chunk, TArray<ETargetPlatform>{Platform}
-                ).GetExFilesByPlatform(Platform);
-                Desc.AllPlatformExFiles.Add(Platform, PlatformFiles);
-            }
+				FPlatformExternFiles PlatformFiles;
+				PlatformFiles.Platform = Platform;
+				PlatformFiles.ExternFiles = UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
+					Context.GetSettingObject(), Context.VersionDiff, Chunk, TArray<ETargetPlatform>{Platform}
+				).GetExFilesByPlatform(Platform);
+				Desc.AllPlatformExFiles.Add(Platform, PlatformFiles);
+			}
 
-            Desc.InternalFiles = Chunk.InternalFiles;
-            Context.ChunkDescribeCache.Add(Chunk.ChunkName, Desc);
-        }
+			Desc.InternalFiles = Chunk.InternalFiles;
+			Context.ChunkDescribeCache.Add(Chunk.ChunkName, Desc);
+		}
 
-        // Build Common chunk describe from CommonPackages
-        if (CommonPackages.Num() > 0)
-        {
-            Context.CommonChunkDescribe = FChunkAssetDescribe();
-            for (const auto& PkgName : CommonPackages)
-            {
-                if (PackageToAssetDetail.Contains(PkgName))
-                {
-                    Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
-                }
-                else
-                {
-                    // try to find detail from any chunk's dep detail map
-                    for (const auto& Pair : ChunkDepDetailMap)
-                    {
-                        if (Pair.Value.Contains(PkgName))
-                        {
-                            Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(Pair.Value[PkgName]);
-                            break;
-                        }
-                    }
-                }
-            }
-            Context.CommonChunkDescribe.Assets = Context.CommonChunkDescribe.AddAssets;
+		//构建分块 公共部分
+		if (CommonDifferencePackages.Num() > 0)
+		{
+			Context.CommonChunkDescribe = FChunkAssetDescribe();
+			for (const auto& PkgName : CommonDifferencePackages)
+			{
+				if (PackageToAssetDetail.Contains(PkgName))
+				{
+					Context.CommonChunkDescribe.AddAssets.AddAssetsDetail(PackageToAssetDetail[PkgName]);
+				}
+			}
 
-            if (Context.CommonChunkDescribe.HasValidAssets())
-            {
-                Context.PakChunks.Add(Context.CommonChunkDescribe.AsChunkInfo(Context.CommonChunkName));
-                Context.ChunkDescribeCache.Add(Context.CommonChunkName, Context.CommonChunkDescribe);
-                UE_LOG(LogHotPatcher, Display, TEXT("Resolved Common chunk with %d shared assets"), CommonPackages.Num());
-            }
-        }
+			Context.CommonChunkDescribe.Assets = Context.CommonChunkDescribe.AddAssets;
+
+			if (Context.CommonChunkDescribe.HasValidAssets())
+			{
+				Context.PakChunks.Add(Context.CommonChunkDescribe.AsChunkInfo(Context.CommonChunkName));
+				Context.ChunkDescribeCache.Add(Context.CommonChunkName, Context.CommonChunkDescribe);
+				UE_LOG(LogHotPatcher, Log, TEXT("Resolved Common chunk with %d shared assets"), CommonDifferencePackages.Num());
+			}
+		}
+
+
 
 		return true;
 	};

--- a/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/FlibHotPatcherCoreHelper.cpp
@@ -38,6 +38,9 @@
 #include "DerivedDataCacheInterface.h"
 #include "HotPatcherRuntime.h"
 #include "Internationalization/PackageLocalizationManager.h"
+#if WITH_UE5
+#include "ZenCookArtifactReader.h"
+#endif
 #include "Misc/ScopeExit.h"
 #include "Misc/EngineVersionComparison.h"
 #if !UE_VERSION_OLDER_THAN(5,4,0)
@@ -347,7 +350,11 @@ FSavePackageContext* UFlibHotPatcherCoreHelper::CreateSaveContext(const ITargetP
 	FString WriterDebugName;
 	if (bUseZenLoader)
 	{
+#if ENGINE_MAJOR_VERSION <= 5 && ENGINE_MINOR_VERSION < 5
 		PackageWriter = new FZenStoreWriter(ResolvedProjectPath, ResolvedMetadataPath, TargetPlatform);
+#else
+		PackageWriter = new FZenStoreWriter(ResolvedProjectPath, ResolvedMetadataPath, TargetPlatform, MakeShareable(new FZenCookArtifactReader(ResolvedProjectPath, ResolvedMetadataPath, TargetPlatform)));
+#endif
 		WriterDebugName = TEXT("ZenStore");
 	}
 	else
@@ -1617,7 +1624,11 @@ bool UFlibHotPatcherCoreHelper::SerializeAssetRegistry(IAssetRegistry* AssetRegi
 	AssetRegistry->InitializeTemporaryAssetRegistryState(State, SaveOptions, true);
 	for(const auto& AssetPackagePath:PackagePaths)
 	{
+#if ENGINE_MAJOR_VERSION <= 5 && ENGINE_MINOR_VERSION < 5
 		if (State.GetAssetByObjectPath(FName(*AssetPackagePath)))
+#else
+		if (State.GetAssetByObjectPath(FSoftObjectPath(*AssetPackagePath)))
+#endif
 		{
 			UE_LOG(LogHotPatcherCoreHelper, Warning, TEXT("%s already add to AssetRegistryState!"), *AssetPackagePath);
 			continue;

--- a/HotPatcher/Source/HotPatcherCore/Private/ShaderLibUtils/FCookShaderCollectionProxy.cpp
+++ b/HotPatcher/Source/HotPatcherCore/Private/ShaderLibUtils/FCookShaderCollectionProxy.cpp
@@ -14,7 +14,11 @@ void FCookShaderCollectionProxy::Init()
 {
 	if(bShareShader)
 	{
+#if ENGINE_MAJOR_VERSION <= 5 && ENGINE_MINOR_VERSION < 5
 		SHADER_COOKER_CLASS::InitForCooking(bIsNative);
+#else
+		SHADER_COOKER_CLASS::InitForCooking(bIsNative, nullptr);
+#endif
 		for(const auto& PlatformName:PlatformNames)
 		{
 			ITargetPlatform* TargetPlatform = UFlibHotPatcherCoreHelper::GetPlatformByName(PlatformName);

--- a/HotPatcher/Source/HotPatcherCore/Public/Cooker/HotPatcherCookerSettingBase.h
+++ b/HotPatcher/Source/HotPatcherCore/Public/Cooker/HotPatcherCookerSettingBase.h
@@ -2,6 +2,7 @@
 // engine
 #include "CoreMinimal.h"
 #include "Engine/EngineTypes.h"
+#include "CreatePatch/HotPatcherSettingBase.h"
 #include "HotPatcherCookerSettingBase.generated.h"
 
 USTRUCT(BlueprintType)

--- a/HotPatcher/Source/HotPatcherEditor/Private/MissionNotificationProxy.cpp
+++ b/HotPatcher/Source/HotPatcherEditor/Private/MissionNotificationProxy.cpp
@@ -66,7 +66,7 @@ void UMissionNotificationProxy::SpawnRuningMissionNotification(FProcWorkerThread
         FNotificationInfo Info(MissionProxy->RunningNotifyText);
 
         Info.bFireAndForget = false;
-		Info.Hyperlink = FSimpleDelegate::CreateStatic([](){ FGlobalTabmanager::Get()->InvokeTab(FName("OutputLog")); });
+		Info.Hyperlink = FSimpleDelegate::CreateStatic([](){ FGlobalTabmanager::Get()->TryInvokeTab(FTabId("OutputLog")); });
         Info.HyperlinkText = LOCTEXT("ShowOutputLogHyperlink", "Show Output Log");
         Info.ButtonDetails.Add(FNotificationButtonInfo(MissionProxy->RunningNofityCancelText, FText(),
             FSimpleDelegate::CreateLambda([MissionProxy]() {MissionProxy->CancelMission(); }),

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPakHelper.cpp
@@ -3,6 +3,7 @@
 
 #include "FlibPakHelper.h"
 #include "IPlatformFilePak.h"
+#include "Misc/EngineVersionComparison.h"
 #if UE_VERSION_OLDER_THAN(5,0,0)
 #include "HAL/PlatformFilemanager.h"
 #else

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
@@ -31,6 +31,8 @@
 #include "Misc/FileHelper.h"
 #include "Serialization/LargeMemoryReader.h"
 
+
+
 TArray<FString> UFlibPatchParserHelper::GetAvailableMaps(FString GameName, bool IncludeEngineMaps, bool IncludePluginMaps, bool Sorted)
 {
 	const FString WildCard = FString::Printf(TEXT("*%s"), *FPackageName::GetMapPackageExtension());
@@ -925,10 +927,10 @@ FChunkAssetDescribe UFlibPatchParserHelper::CollectFChunkAssetsDescribeByChunk(
 {
 	SCOPED_NAMED_EVENT_TEXT("CollectFChunkAssetsDescribeByChunk",FColor::Red);
 	FChunkAssetDescribe ChunkAssetDescribe;
-	
+
 	{
-		ChunkAssetDescribe.AddAssets = DiffInfo.AssetDiffInfo.AddAssetDependInfo; // CollectChunkAssets(AddAssetsRef, AssetFilterPaths);
-		ChunkAssetDescribe.ModifyAssets = DiffInfo.AssetDiffInfo.ModifyAssetDependInfo; //CollectChunkAssets(ModifyAssetsRef, AssetFilterPaths);
+		ChunkAssetDescribe.AddAssets = DiffInfo.AssetDiffInfo.AddAssetDependInfo;
+		ChunkAssetDescribe.ModifyAssets = DiffInfo.AssetDiffInfo.ModifyAssetDependInfo;
 		ChunkAssetDescribe.Assets = UFlibAssetManageHelper::CombineAssetDependencies(ChunkAssetDescribe.AddAssets, ChunkAssetDescribe.ModifyAssets);
 	}
 

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibPatchParserHelper.cpp
@@ -1198,6 +1198,80 @@ FHotPatcherVersion UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
 	return ExportVersion;
 }
 
+FHotPatcherVersion UFlibPatchParserHelper::DiffAssetByChunk(const FPatchVersionDiff& Diff, const FChunkInfo& InChunkInfo, bool bInAnalysisFilterDependencies, EHashCalculator HashCalculator)
+{
+	SCOPED_NAMED_EVENT_TEXT("DiffAssetByChunk", FColor::Red);
+	FHotPatcherVersion ExportVersion;
+
+	FHotPatcherVersion ChunkVersion = UFlibPatchParserHelper::ExportReleaseVersionInfoByChunk(
+		TEXT(""), TEXT(""), TEXT(""),
+		InChunkInfo,
+		false,
+		bInAnalysisFilterDependencies,
+		HashCalculator
+	);
+
+	TSet<FString> ChunkAssetSet;
+	for (const auto& Asset : ChunkVersion.AssetInfo.GetAssetDetails())
+	{
+		ChunkAssetSet.Add(UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString()));
+	}
+
+	auto AppendDiffAssetIfMatched = [&ExportVersion, &ChunkAssetSet](const TArray<FAssetDetail>& InAssets)
+	{
+		for (const auto& Asset : InAssets)
+		{
+			FString LongPackageName = UFlibAssetManageHelper::PackagePathToLongPackageName(Asset.PackagePath.ToString());
+			if (ChunkAssetSet.Contains(LongPackageName))
+			{
+				ExportVersion.AssetInfo.AddAssetsDetail(Asset);
+			}
+		}
+	};
+
+	AppendDiffAssetIfMatched(Diff.AssetDiffInfo.AddAssetDependInfo.GetAssetDetails());
+	AppendDiffAssetIfMatched(Diff.AssetDiffInfo.ModifyAssetDependInfo.GetAssetDetails());
+
+	for (const auto& PlatformConfig : InChunkInfo.AddExternAssetsToPlatform)
+	{
+		if (!Diff.PlatformExternDiffInfo.Contains(PlatformConfig.TargetPlatform))
+		{
+			continue;
+		}
+
+		const FPatchVersionExternDiff& PlatformDiff = Diff.PlatformExternDiffInfo[PlatformConfig.TargetPlatform];
+		FPlatformExternAssets PlatformAssets;
+		PlatformAssets.TargetPlatform = PlatformConfig.TargetPlatform;
+
+		TSet<FString> ChunkExternFiles;
+		for (const auto& File : PlatformConfig.AddExternFileToPak)
+		{
+			ChunkExternFiles.Add(File.GetReplaceMarkdFilePath());
+		}
+
+		auto CollectMatchedExternFiles = [&PlatformAssets, &ChunkExternFiles](const TArray<FExternFileInfo>& InFiles)
+		{
+			for (const auto& File : InFiles)
+			{
+				if (ChunkExternFiles.Contains(File.GetReplaceMarkdFilePath()))
+				{
+					PlatformAssets.AddExternFileToPak.AddUnique(File);
+				}
+			}
+		};
+
+		CollectMatchedExternFiles(PlatformDiff.AddExternalFiles);
+		CollectMatchedExternFiles(PlatformDiff.ModifyExternalFiles);
+
+		if (PlatformAssets.AddExternFileToPak.Num())
+		{
+			ExportVersion.PlatformAssets.Add(PlatformConfig.TargetPlatform, PlatformAssets);
+		}
+	}
+
+	return ExportVersion;
+}
+
 void UFlibPatchParserHelper::RunAssetScanner(FAssetScanConfig ScanConfig,FHotPatcherVersion& ExportVersion)
 {
 	SCOPED_NAMED_EVENT_TEXT("UFlibPatchParserHelper::RunAssetScanner",FColor::Red);

--- a/HotPatcher/Source/HotPatcherRuntime/Private/FlibReflectionHelper.cpp
+++ b/HotPatcher/Source/HotPatcherRuntime/Private/FlibReflectionHelper.cpp
@@ -2,6 +2,7 @@
 
 
 #include "FlibReflectionHelper.h"
+#include "Resources/Version.h"
 
 FProperty* UFlibReflectionHelper::GetPropertyByName(UClass* Class, FName PropertyName)
 {
@@ -23,7 +24,11 @@ FString UFlibReflectionHelper::ExportPropertyToText(UObject* Object, FName Prope
 	FProperty* Property = GetPropertyByName(Object->GetClass(),PropertyName);
 	if(Property)
 	{
+#if ENGINE_MAJOR_VERSION <= 5 && ENGINE_MINOR_VERSION < 5
 		Property->ExportTextItem(Value,Property->ContainerPtrToValuePtr<uint8>(Object),nullptr,Object,0);
+#else
+		Property->ExportTextItem_Direct(Value,Property->ContainerPtrToValuePtr<uint8>(Object),nullptr,Object,0);
+#endif
 	}
 	return Value;
 }
@@ -33,7 +38,11 @@ bool UFlibReflectionHelper::ImportPropertyValueFromText(UObject* Object, FName P
 	FProperty* Property = GetPropertyByName(Object->GetClass(),PropertyName);
 	if(Property)
 	{
+#if ENGINE_MAJOR_VERSION <= 5 && ENGINE_MINOR_VERSION < 5
 		Property->ImportText(*Text,Property->ContainerPtrToValuePtr<uint8>(Object),0,Object);
+#else
+		Property->ImportText_Direct(*Text,Property->ContainerPtrToValuePtr<uint8>(Object),Object,0);
+#endif
 	}
 	return true;
 }

--- a/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDetail.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/BaseTypes/AssetManager/FAssetDetail.h
@@ -31,6 +31,11 @@ struct HOTPATCHERRUNTIME_API FAssetDetail
 	{
 		return !PackagePath.IsNone() && !AssetType.IsNone() && !Guid.IsNone();
 	}
+	
+	friend uint32 GetTypeHash(const FAssetDetail& Data)
+	{
+		return GetTypeHash(Data.Guid);
+	}
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 		FName PackagePath;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)

--- a/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherContext.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/CreatePatch/HotPatcherContext.h
@@ -110,6 +110,11 @@ struct HOTPATCHERRUNTIME_API FHotPatcherPatchContext:public FHotPatcherContext
 
     UPROPERTY(EditAnywhere)
     TArray<FPakCommand> AdditionalFileToPak;
+
+    // Common chunk resolution cache
+    TMap<FString, FChunkAssetDescribe> ChunkDescribeCache;
+    FChunkAssetDescribe CommonChunkDescribe;
+    FString CommonChunkName = TEXT("Common");
     
     // every pak file info
     // TArray<FPakFileProxy> PakFileProxys;

--- a/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
+++ b/HotPatcher/Source/HotPatcherRuntime/Public/FlibPatchParserHelper.h
@@ -57,6 +57,10 @@ public:
 		bool InIncludeHasRefAssetsOnly = false,
 		bool bInAnalysisFilterDependencies = true, EHashCalculator HashCalculator = EHashCalculator::NoHash
 	);
+	//����Diff���� ����ʲ� ���õĻ�ȡ
+	static FHotPatcherVersion DiffAssetByChunk(const FPatchVersionDiff& Diff ,const FChunkInfo& InChunkInfo, bool bInAnalysisFilterDependencies = true, EHashCalculator HashCalculator = EHashCalculator::NoHash );
+
+
 	static void RunAssetScanner(FAssetScanConfig ScanConfig,FHotPatcherVersion& ExportVersion);
 	static void ExportExternAssetsToPlatform(const TArray<FPlatformExternAssets>& AddExternAssetsToPlatform, FHotPatcherVersion& ExportVersion, bool bGenerateHASH, EHashCalculator
 	                                         HashCalculator);


### PR DESCRIPTION
基于diff进行分块 增量更新
现测试完成:
1、无基础版本可正常进行分块收集资产生成pak
2、有基础版本正常进行对比差异并成功分块收集资产生成pak
3、外部文件也可正常收集并生成pak
修改总结
1、在PatcherProxy.cpp中生成pak管线中第7第8步骤之间加入了
步骤7.15 ResolveCommonChunkWorker数
目标是为了分块收集资产信息并将共有资产生成到Common分块中
2. 添加了UFlibPatchParserHelper::DiffAssetByChunk
函数
目标是为了直接让分块根据diff将引用资产获取
3. 更改了 部分GeneratePakProxysWorker
目标为了兼容7.15的修改